### PR TITLE
Refactor: Remove cloudbuild.yaml and update README for trigger-based …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application's code from the host to the image's filesystem at /app
+COPY app.py .
+
+# Make port 8501 available to the world outside this container
+EXPOSE 8501
+
+# Run app.py when the container launches
+CMD ["streamlit", "run", "app.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # restaurants_FSA
 uses public FSA data to extract restaurant information
+
+## Streamlit Application
+
+This repository contains a simple Streamlit application.
+
+## Running Locally with Docker
+
+1.  **Build the Docker image:**
+    ```bash
+    docker build -t streamlit-app .
+    ```
+2.  **Run the Docker container:**
+    ```bash
+    docker run -p 8501:8501 streamlit-app
+    ```
+    The application will be accessible at `http://localhost:8501`.
+
+## Deploying to Google Cloud Run
+
+This project can be deployed to Google Cloud Run using a Cloud Build trigger.
+
+1.  **Prerequisites:**
+    *   A Google Cloud Project with billing enabled.
+    *   Cloud Build API and Cloud Run API enabled in your GCP project.
+    *   Your repository (e.g., on GitHub, Bitbucket, or Cloud Source Repositories) connected to Google Cloud Build.
+
+2.  **Configure a Cloud Build Trigger:**
+    *   In the Google Cloud Console, navigate to Cloud Build and create a new trigger.
+    *   Connect it to your source code repository.
+    *   Configure the trigger to build from your `Dockerfile` when changes are pushed to your desired branch (e.g., `main` or `master`).
+    *   In the build steps for the trigger, ensure it performs the following actions:
+        1.  Builds the Docker image using the `Dockerfile`:
+            `docker build -t gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA .`
+        2.  Pushes the image to Google Container Registry (GCR):
+            `docker push gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA`
+        3.  Deploys the image to Cloud Run:
+            `gcloud run deploy $REPO_NAME --image gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA --platform managed --region YOUR_REGION --allow-unauthenticated`
+            (Replace `YOUR_REGION` with your desired Google Cloud region, e.g., `us-central1`. You can also parameterize `$REPO_NAME` or hardcode your service name).
+
+3.  **Triggering a Deployment:**
+    Pushing changes to the configured branch in your repository will automatically trigger the Cloud Build pipeline, which will build and deploy your Streamlit application to Cloud Run.
+
+4.  **Access the application:**
+    Once deployed, Google Cloud Run will provide a URL to access your application.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,7 @@
+import streamlit as st
+
+def main():
+    st.title("Hello, World!")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit


### PR DESCRIPTION
…deployment

This commit removes the `cloudbuild.yaml` file as per your feedback, opting for a trigger-based deployment strategy via Google Cloud Build.

The `README.md` has been updated to:
- Remove instructions related to `cloudbuild.yaml` and the `gcloud builds submit` command.
- Provide guidance on configuring a Cloud Build trigger in the Google Cloud Console to build the Docker image from the Dockerfile and deploy it to Cloud Run.