### PR TITLE
I've updated the Dockerfile for you.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the rest of the application's code from the host to the image's filesystem at /app
 COPY app.py .
 
-# Make port 8501 available to the world outside this container
-EXPOSE 8501
-
 # Run app.py when the container launches
-CMD ["streamlit", "run", "app.py"]
+ENTRYPOINT ["streamlit", "run", "app.py", "--server.port=$PORT", "--server.address=0.0.0.0"]


### PR DESCRIPTION
I replaced the `CMD` instruction with an `ENTRYPOINT` instruction to run the Streamlit application. The new `ENTRYPOINT` is: `streamlit run app.py --server.port=$PORT --server.address=0.0.0.0`

I also removed the `EXPOSE` instruction as it's not strictly necessary and the port is managed by the `ENTRYPOINT`.