### PR TITLE
feat: Display API results as a Pandas DataFrame in Streamlit app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 requests
+pandas

--- a/st_app.py
+++ b/st_app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import requests
 import json
+import pandas as pd
 
 # Set the title of the Streamlit app
 st.title("Food Standards Agency API Explorer")
@@ -22,6 +23,15 @@ if st.button("Fetch Data"):
         if response.status_code == 200:
             # Store the JSON response
             data = response.json()
+
+            try:
+                establishments = data['FHRSEstablishment']['EstablishmentCollection']['EstablishmentDetail']
+                df = pd.json_normalize(establishments)
+                st.dataframe(df)
+            except KeyError:
+                st.error("Error: Could not find the expected data structure in the API response.")
+            except TypeError: # Handles cases where establishments might be None if the key path is valid but no data
+                st.warning("No establishment data found in the response, or the data format is unexpected.")
 
             # Display a download button for the JSON data
             st.download_button(


### PR DESCRIPTION
Integrates Pandas to process data from the Food Standards Agency API. The API response, previously only available as a JSON download, is now parsed into a Pandas DataFrame. This DataFrame is then displayed in the Streamlit application, allowing you to view the structured data directly.

Changes include:
- Added `pandas` to `st_app.py` and `requirements.txt`.
- Implemented logic in `st_app.py` to:
    - Extract establishment details from the API JSON response.
    - Normalize the JSON data (including nested 'Scores' and 'Geocode' objects) into a Pandas DataFrame.
    - Handle potential KeyErrors if the JSON structure is unexpected.
- Used `st.dataframe()` to render the DataFrame in the app.