### PR TITLE
Refactor: Simplify master list loading logic in section 1.a

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -86,43 +86,26 @@ if st.button("Fetch Data"):
             # 1.a. Load Master List
             restaurants_master_list = []
             if master_list_uri:
-                loaded_master_data = load_json_from_uri(master_list_uri)
-                if loaded_master_data is not None:
-                    if isinstance(loaded_master_data, list):
-                        restaurants_master_list = loaded_master_data
+                loaded_data = load_json_from_uri(master_list_uri)
+                if loaded_data is not None:
+                    if isinstance(loaded_data, list):
+                        restaurants_master_list = loaded_data
                         if restaurants_master_list:
-                            st.info(f"Successfully loaded master list with {len(restaurants_master_list)} items.")
+                            st.success(f"Successfully loaded master list with {len(restaurants_master_list)} items from {master_list_uri}.")
                         else:
-                            st.warning("Master list loaded, but it's an empty list.")
-                    elif isinstance(loaded_master_data, dict):
-                        if loaded_master_data: # If dictionary is not empty
-                            found_list_in_dict = False
-                            for value in loaded_master_data.values():
-                                if isinstance(value, list):
-                                    restaurants_master_list = value
-                                    st.info(f"Master list loaded. Found a list with {len(restaurants_master_list)} items within the dictionary.")
-                                    found_list_in_dict = True
-                                    break 
-                            if not found_list_in_dict:
-                                restaurants_master_list = [loaded_master_data]
-                                st.info("Master list loaded. Treating the non-empty dictionary as a single record.")
-                        else: # Empty dictionary
-                            st.warning("Master list loaded, but it's an empty dictionary. Proceeding with an empty master list.")
-                            restaurants_master_list = [] # Ensure it's empty
-                    else: # Not a list or dict (e.g. string, number)
-                        st.warning(f"Master list loaded from {master_list_uri}, but it is not a list or dictionary (type: {type(loaded_master_data)}). Proceeding with an empty master list.")
-                        restaurants_master_list = [] # Ensure it's empty
+                            st.warning(f"Master list loaded from {master_list_uri}, but it's an empty list.")
+                    else:
+                        # This case should ideally not happen if load_json_from_uri is robust
+                        # and the JSON structure is expected to be a list at the root.
+                        st.warning(f"Data loaded from {master_list_uri} is not a list (type: {type(loaded_data)}). Proceeding with an empty master list.")
+                        restaurants_master_list = []
                 else:
-                    # load_json_from_uri already shows an error via st.error
-                    st.warning("Failed to load master list (it was None or loading failed). Proceeding with an empty master list.")
-                    restaurants_master_list = [] # Ensure it's empty
+                    # load_json_from_uri handles st.error for specific loading issues.
+                    st.warning(f"Failed to load master list from {master_list_uri} (or it was empty/invalid). Proceeding with an empty master list.")
+                    restaurants_master_list = [] # Ensure it's an empty list on failure
             else:
                 st.info("No master list URI provided. Starting with an empty master list.")
-            
-            # Ensure restaurants_master_list is always a list, even if logic above has a flaw
-            if not isinstance(restaurants_master_list, list):
-                st.warning(f"restaurants_master_list was unexpectedly not a list (type: {type(restaurants_master_list)} after processing). Resetting to an empty list.")
-                restaurants_master_list = []
+                restaurants_master_list = [] # Ensure it's an empty list if no URI
 
             # 1.b. Process API Response and Update Master List
             api_establishments = data.get('FHRSEstablishment', {}).get('EstablishmentCollection', {}).get('EstablishmentDetail', [])


### PR DESCRIPTION
I've significantly simplified the master list loading process in st_app.py (section 1.a). The updated logic now directly uses the output of `load_json_from_uri`. If a list is returned, it is used as the master list. If `None` or any other data type is returned (e.g. dict, str), or if no URI is provided, the master list defaults to an empty list. I'll display appropriate feedback messages (st.success, st.warning, st.info) based on the outcome.

This change removes the previous complex handling of different dictionary structures and type coercions, making the code cleaner and more aligned with the requirement that the master list URI should point to a JSON file containing a list of restaurants.

I've also updated the test suite in `test_st_app.py` accordingly:
- I refactored the `_run_fetch_data_logic` helper method to use the new simplified logic.
- I removed obsolete tests for the old complex loading behavior.
- I verified or adapted existing tests.
- I added new tests to cover the behavior of the simplified logic, including cases for valid lists, empty lists, load failures (None return), and incorrect data types being returned by `load_json_from_uri`.