### PR TITLE
Clarify GCS input label for scan destination

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -64,7 +64,7 @@ longitude = st.number_input("Enter Longitude", format="%.6f")
 latitude = st.number_input("Enter Latitude", format="%.6f")
 
 # Create an input field for the GCS destination folder URI
-gcs_destination_uri = st.text_input("Enter GCS Destination Folder URI for API Response (e.g., gs://bucket-name/folder-name)")
+gcs_destination_uri = st.text_input("Enter GCS destination folder for the scan (e.g., gs://bucket-name/scans-folder/)")
 
 # Create an input field for the master restaurant list URI
 master_list_uri = st.text_input("Enter Master Restaurant List URI (e.g., gs://bucket/file.json or /path/to/file.json)")


### PR DESCRIPTION
The issue requested to ensure GCS related inputs in Streamlit are named and treated appropriately.

This commit updates the label for the GCS destination folder for the API scan results to be more aligned with the terminology used in the issue description ("scan" instead of "API Response").

- Changed label for `gcs_destination_uri` from "Enter GCS Destination Folder URI for API Response..." to "Enter GCS destination folder for the scan..."

Other GCS input labels and their handling were reviewed and found to be appropriate, requiring no changes:
- `master_list_uri` (for reading the master file)
- `gcs_master_dictionary_output_uri` (for writing the master file)

The core logic for handling these GCS paths (folder for scan data, full file path for master list read/write) remains unchanged as it correctly implements the required behavior.