### PR TITLE
feat: Integrate BigQuery for storing restaurant data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 requests
 pandas
 google-cloud-storage
+google-cloud-bigquery


### PR DESCRIPTION
This commit introduces the functionality to write the processed restaurant data to a Google BigQuery table.

Key changes:
- Added `google-cloud-bigquery` to project dependencies.
- Introduced a new Streamlit input field for you to specify the target BigQuery table name.
- Implemented the `write_to_bigquery` function in `st_app.py` which:
    - Takes a pandas DataFrame, project ID, dataset ID, and table ID.
    - Uses the `WRITE_TRUNCATE` disposition to overwrite the table if it exists.
    - Retrieves the target dataset (project.dataset) from an environment variable `BQ_DATASET_ID`.
- The main application logic in `st_app.py` now calls `write_to_bigquery` after data processing, using the table name you provided and the dataset specified in the environment.
- Added unit tests for the `write_to_bigquery` function in `test_st_app.py` to cover success and failure scenarios, ensuring correct DataFrame handling and BigQuery client interaction.