### PR TITLE
Fix: Use column_name_character_map V2 for BigQuery loads

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -260,6 +260,7 @@ def write_to_bigquery(df: pd.DataFrame, project_id: str, dataset_id: str, table_
     
     job_config = bigquery.LoadJobConfig(
         write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        column_name_character_map="V2",
     )
     
     try:


### PR DESCRIPTION
This change addresses an error that occurs when you're writing tables to BigQuery due to invalid characters in column names. By setting `column_name_character_map="V2"` in the `LoadJobConfig`, BigQuery will automatically modify field names to comply with its naming rules, preventing the error: 'Please change your field name or use character map V2 to let the system modify the field names.'