### PR TITLE
Fix: Limit longitude and latitude inputs to 3 decimal places

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -277,8 +277,8 @@ def write_to_bigquery(df: pd.DataFrame, project_id: str, dataset_id: str, table_
 st.title("Food Standards Agency API Explorer")
 
 # Create input fields for longitude and latitude
-longitude = st.number_input("Enter Longitude", format="%.6f")
-latitude = st.number_input("Enter Latitude", format="%.6f")
+longitude = st.number_input("Enter Longitude", format="%.3f")
+latitude = st.number_input("Enter Latitude", format="%.3f")
 
 # Create an input field for the GCS destination folder URI
 gcs_destination_uri = st.text_input("Enter GCS destination folder for the scan (e.g., gs://bucket-name/scans-folder/)")


### PR DESCRIPTION
The Streamlit number_input widgets for longitude and latitude were previously configured with `format="%.6f"`, allowing up to six decimal places.

This change updates the format string to `format="%.3f"`, restricting the input to three decimal places as requested.

No specific tests for this UI change were added, as it would require a UI testing framework. The change is straightforward and can be manually verified.