### PR TITLE
Refactor: Ensure RatingDate is always treated as string

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -464,12 +464,6 @@ def handle_fetch_data_action(
         if master_restaurant_data: # Check if master data (potentially enriched) exists
             df_to_load = pd.json_normalize([item for item in master_restaurant_data if isinstance(item, dict)])
 
-            # Convert 'RatingDate' to datetime objects
-            if 'RatingDate' in df_to_load.columns:
-                df_to_load['RatingDate'] = pd.to_datetime(df_to_load['RatingDate'], errors='coerce')
-            else:
-                st.warning("Column 'RatingDate' not found in DataFrame. Skipping datetime conversion for it.")
-
             # Ensure other potential date columns are handled if necessary,
             # for now, the issue is specifically with 'RatingDate'.
             # The 'first_seen' column is already a string in 'YYYY-MM-DD' format,
@@ -503,7 +497,7 @@ def handle_fetch_data_action(
                                     bigquery.SchemaField(sanitize_column_name('PostCode'), 'STRING'),
                                     bigquery.SchemaField(sanitize_column_name('RatingValue'), 'STRING'), # RatingValue can be non-numeric e.g. "Exempt"
                                     bigquery.SchemaField(sanitize_column_name('RatingKey'), 'STRING'),
-                                    bigquery.SchemaField(sanitize_column_name('RatingDate'), 'TIMESTAMP'),
+                                    bigquery.SchemaField(sanitize_column_name('RatingDate'), 'STRING'),
                                     bigquery.SchemaField(sanitize_column_name('LocalAuthorityName'), 'STRING'),
                                     bigquery.SchemaField(sanitize_column_name('Scores.Hygiene'), 'INTEGER'),
                                     bigquery.SchemaField(sanitize_column_name('Scores.Structural'), 'STRING'),

--- a/test_st_app.py
+++ b/test_st_app.py
@@ -193,7 +193,7 @@ class TestWriteToBigQuery(unittest.TestCase):
 
         self.assertIsInstance(df_passed_to_bq, pd.DataFrame)
         self.assertTrue('RatingDate' in df_passed_to_bq.columns)
-        self.assertEqual(df_passed_to_bq['RatingDate'].dtype, 'datetime64[ns]')
+        self.assertTrue(pd.api.types.is_string_dtype(df_passed_to_bq['RatingDate']) or pd.api.types.is_object_dtype(df_passed_to_bq['RatingDate']), "RatingDate column should have string or object dtype")
         
         # Check 'first_seen' which is added by process_and_update_master_data
         self.assertTrue('first_seen' in df_passed_to_bq.columns) 


### PR DESCRIPTION
I've made sure the "RatingDate" column is now consistently processed as a string throughout your application.

Changes include:
- I removed the explicit conversion of 'RatingDate' to datetime objects in `st_app.py` before writing to BigQuery.
- I updated the BigQuery schema in `st_app.py` to define 'RatingDate' as STRING instead of TIMESTAMP.
- I modified `test_handle_fetch_data_action_rating_date_conversion` in `test_st_app.py` to assert that 'RatingDate' maintains a string/object dtype in the DataFrame.
- I verified that `test_write_to_bigquery_with_selection_and_schema` correctly reflects 'RatingDate' as a string for BigQuery schema purposes.

This ensures that the original string representation of "RatingDate", as fetched from the API or other sources, is preserved, particularly when stored in BigQuery.