### PR TITLE
Fix: Ensure Scores.Hygiene is integer for BigQuery

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -510,6 +510,14 @@ def handle_fetch_data_action(
                                 sanitized_columns_to_select_set = {sanitize_column_name(col) for col in columns_to_select}
                                 bq_schema = [field for field in bq_schema if field.name in sanitized_columns_to_select_set]
 
+                                # Convert 'Scores.Hygiene' to Int64
+                                hygiene_col = 'Scores.Hygiene'
+                                if hygiene_col in df_to_load.columns:
+                                    st.write(f"Attempting to convert column: {hygiene_col}") # Added for debugging visibility
+                                    df_to_load[hygiene_col] = pd.to_numeric(df_to_load[hygiene_col], errors='coerce')
+                                    df_to_load[hygiene_col] = df_to_load[hygiene_col].astype('Int64')
+                                    st.write(f"Conversion of {hygiene_col} complete. Dtype: {df_to_load[hygiene_col].dtype}") # Added for debugging
+
                                 write_to_bigquery(df_to_load, project_id, dataset_id, table_id, columns_to_select, bq_schema)
                             else: 
                                 st.error(f"Invalid BigQuery Table Path format. Each part of 'project.dataset.table' must be non-empty. Got: '{bq_full_path_str}'. Skipping BigQuery write.")


### PR DESCRIPTION
This addresses a potential BigQuery error: "Could not convert 'X' with type str: tried to convert to int64" for the 'Scores.Hygiene' column.

Here's what I did:
- I've made sure the 'Scores.Hygiene' column in the DataFrame is explicitly converted to a nullable integer type (Int64) using pandas.to_numeric with errors='coerce' before writing to BigQuery. This will handle non-numeric values gracefully.
- I've also added some debug logging during this conversion process.

I confirmed that the existing `write_to_bigquery` function correctly sanitizes column names, ensuring alignment between the DataFrame and the BigQuery schema names.