### PR TITLE
Fix: Update Dockerfile to copy all .py files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application's code from the host to the image's filesystem at /app
-COPY st_app.py .
+COPY *.py .
 
 # Run app.py when the container launches
 ENTRYPOINT streamlit run st_app.py --server.port=$PORT --server.address=0.0.0.0


### PR DESCRIPTION
This change addresses an ImportError for local modules (e.g., api_client.py) when running the Streamlit application in a Docker container. The previous Dockerfile only copied st_app.py, leading to missing modules at runtime. By changing `COPY st_app.py .` to `COPY *.py .`, all Python files in the root directory are now included in the Docker image's /app directory, making them accessible for import.