### PR TITLE
Fix: Correct COPY instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application's code from the host to the image's filesystem at /app
-COPY *.py .
+COPY *.py ./
 
 # Run app.py when the container launches
 ENTRYPOINT streamlit run st_app.py --server.port=$PORT --server.address=0.0.0.0


### PR DESCRIPTION
The previous Dockerfile was failing during the build process at the step where Python files were being copied. The error message "When using COPY with more than one source file, the destination must be a directory and end with a /" indicated that the destination path for the `COPY *.py .` instruction was missing a trailing slash.

This commit fixes the issue by changing the instruction to `COPY *.py ./`, explicitly telling Docker to treat the destination as a directory. This allows the Docker image to be built successfully.