### PR TITLE
feat: Add Cloud Run deployment step to cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,5 +17,19 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['push', 'gcr.io/$PROJECT_ID/python-app:$COMMIT_SHA']
 
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'services'
+      - 'update'
+      - 'restaurants-fsa'
+      - '--platform=managed'
+      - '--image=gcr.io/$PROJECT_ID/python-app:$COMMIT_SHA'
+      - '--labels=managed-by=gcp-cloud-build-deploy-cloud-run'
+      - '--region=europe-west2'
+      - '--quiet'
+
 images:
   - 'gcr.io/$PROJECT_ID/python-app:$COMMIT_SHA'


### PR DESCRIPTION
This change adds a new step to the cloudbuild.yaml file to deploy the published Docker image to Google Cloud Run.

The new step uses the gcloud command-line tool to update the 'restaurants-fsa' service with the newly built image. It specifies the platform, image, labels, and region for the deployment.