### PR TITLE
Fix: Update test assertions for update_manual_review

### DIFF
--- a/test_st_app.py
+++ b/test_st_app.py
@@ -183,7 +183,7 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
             main_ui()
 
             mock_update_review.assert_called_once_with(
-                fhrsid=fhrsid,
+                fhrsid_list=[fhrsid],
                 manual_review_value=new_review_value,
                 project_id="proj",
                 dataset_id="dset",
@@ -229,7 +229,7 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
             main_ui()
 
             mock_update_review.assert_called_once_with(
-                fhrsid=fhrsid,
+                fhrsid_list=[fhrsid],
                 manual_review_value=new_review_value,
                 project_id="proj",
                 dataset_id="dset",


### PR DESCRIPTION
The `update_manual_review` function in `st_app.py` was modified to accept a list of FHRSIDs (`fhrsid_list`) to support bulk updates. However, the corresponding tests in `test_st_app.py` were still expecting the mock of this function to be called with a singular `fhrsid` argument.

This commit updates the assertions in the following tests:
- `test_main_ui_update_workflow_success_single_fhrsid`
- `test_main_ui_update_workflow_update_fails`

The assertions now correctly expect `fhrsid_list` as an argument, aligning the tests with the actual function signature and resolving the test failures.