### PR TITLE
Fix: Enhance FHRSID lookup robustness and diagnostics

### DIFF
--- a/bq_utils.py
+++ b/bq_utils.py
@@ -115,6 +115,12 @@ def read_from_bigquery(fhrsid_list: List[str], project_id: str, dataset_id: str,
     try:
         query_job = client.query(query, job_config=job_config)
 
+        if query_job.errors:
+            error_messages = [error['message'] for error in query_job.errors]
+            print(f"BigQuery job errors for FHRSIDs {', '.join(fhrsid_list)} from table {table_ref_str}: {'; '.join(error_messages)}")
+            # Optionally, you might decide to return None here if errors are severe
+            # For now, let's log and continue to see if to_dataframe() still works or fails
+
         try:
             df = query_job.to_dataframe()
         except Exception as df_conversion_error:
@@ -123,7 +129,7 @@ def read_from_bigquery(fhrsid_list: List[str], project_id: str, dataset_id: str,
             return None
 
         if df.empty:
-            # Using st.info for user-facing messages in Streamlit context, print for backend/CLI
+            print(f"Query executed successfully but returned no data for FHRSIDs: {', '.join(fhrsid_list)} from table {table_ref_str}")
             return None
 
         return df

--- a/st_app.py
+++ b/st_app.py
@@ -74,6 +74,7 @@ def fhrsid_lookup_logic(fhrsid_input_str: str, bq_table_lookup_input_str: str, s
             return
 
         fhrsid_list_requested = [fhrsid.strip() for fhrsid in fhrsid_input_str.split(':') if fhrsid.strip()]
+        fhrsid_list_requested = [f_id for f_id in fhrsid_list_requested if f_id]
         if not fhrsid_list_requested:
             st_object.error("Please enter valid FHRSIDs.")
             return


### PR DESCRIPTION
This commit introduces two main improvements:

1.  **Refined FHRSID List Preparation (`st_app.py`):** In `fhrsid_lookup_logic`, an additional filter was added to ensure that the list of FHRSIDs passed to the BigQuery lookup function (`read_from_bigquery`) is explicitly cleaned of any empty strings. This serves as an extra safeguard for input integrity.

2.  **Enhanced Diagnostics in BigQuery Utils (`bq_utils.py`):** The `read_from_bigquery` function was updated to:
    - Check and log `query_job.errors` immediately after a query is dispatched to BigQuery. This provides early insight into any job-level errors reported by BigQuery.
    - Log a specific message when a query executes successfully but returns an empty DataFrame. This helps distinguish between a query that found no matching data and a query that failed to execute or encountered other issues.

These changes aim to make the FHRSID lookup feature more robust to varied inputs and provide better logging for diagnosing issues related to BigQuery interactions, particularly for cases involving multiple FHRSID lookups.