### PR TITLE
Refactor FHRSID lookup to use pandas-gbq and simplify logic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ requests
 pandas
 google-cloud-storage
 google-cloud-bigquery
+pandas-gbq
 pytest
 db-dtypes

--- a/test_st_app.py
+++ b/test_st_app.py
@@ -7,93 +7,64 @@ import streamlit as st # We will mock this heavily
 # Assuming st_app.py is in the same directory or accessible via PYTHONPATH
 from st_app import fhrsid_lookup_logic, main_ui
 # We also need to patch functions imported by st_app, like read_from_bigquery and update_manual_review
+# Also, BigQueryExecutionError may be raised by read_from_bigquery
+from bq_utils import BigQueryExecutionError
 
 # Helper class to simulate streamlit.SessionState more directly
-class MockSessionState:
-    def __init__(self, state_dict):
-        self._state = state_dict
+class MockSessionState(dict): # Inherit from dict for easier state management
+    def __init__(self, initial_state=None):
+        if initial_state is None:
+            initial_state = {}
+        super().__init__(initial_state)
+        # Ensure essential keys are present, mimicking Streamlit's behavior for uninitialized state
+        self.setdefault('fhrsid_df', pd.DataFrame()) # Initialize with empty DataFrame
+        self.setdefault('successful_fhrsids', [])
+        self.setdefault('fhrsid_input_str_ui',"")
+        self.setdefault('bq_table_lookup_input_str_ui',"")
 
-    def __getitem__(self, key):
-        if key not in self._state:
-            if key == 'fhrsid_df': return None
-            if key == 'successful_fhrsids': return []
-            raise KeyError(key)
-        return self._state[key]
-
-    def __setitem__(self, key, value):
-        self._state[key] = value
-
-    def __contains__(self, key):
-        return key in self._state
 
     def __getattr__(self, key):
-        if key == '_state':
-            return super().__getattribute__(key)
-
-        if key not in self._state:
-            if key == 'fhrsid_df': return None
-            if key == 'successful_fhrsids': return []
-            return None
-
-        return self._state.get(key)
+        # Allow attribute-style access for keys that exist
+        if key in self:
+            return self[key]
+        # Default behavior for common Streamlit session_state attributes if not set
+        if key == 'fhrsid_df': return pd.DataFrame()
+        if key == 'successful_fhrsids': return []
+        # Fallback to raising AttributeError if key genuinely doesn't exist and has no default
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{key}' and no default defined")
 
     def __setattr__(self, key, value):
-        if key == '_state':
-            object.__setattr__(self, key, value)
-            return
-        self._state[key] = value
+        self[key] = value
+
 
 class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
 
     def setUp(self):
-        # Mock st.session_state for each test
-        # We'll patch 'st_app.st' which is the alias used in st_app.py
-        # The mock_st_object will then have a 'session_state' attribute we can control.
-        
-        # Basic session state structure that will be fresh for each test via _run_test_with_patches
+        # Basic session state structure that will be fresh for each test
         self.base_session_state_dict = {
-            'fhrsid_df': None,
+            'fhrsid_df': pd.DataFrame(), # Default to empty DataFrame
             'successful_fhrsids': [],
             'fhrsid_input_str_ui': "",
             'bq_table_lookup_input_str_ui': ""
         }
-        # Each test starts with self.current_mock_session_state_dict as a fresh copy of base.
-        self.current_mock_session_state_dict = self.base_session_state_dict.copy()
-
+        # Each test starts with self.current_mock_session_state as a fresh instance.
+        self.current_mock_session_state = MockSessionState(self.base_session_state_dict.copy())
 
     # Helper to apply common patches and manage session_state
     def _run_test_with_patches(self, test_logic_func, mock_st_extras=None):
-        # self.current_mock_session_state_dict is now prepared by setUp and can be
-        # further modified by the test method before calling this helper.
-
         with patch('st_app.st', autospec=True) as mock_st_global, \
              patch('st_app.read_from_bigquery') as mock_read_from_bq, \
-             patch('st_app.update_manual_review') as mock_update_review, \
-             patch('st_app.pd.concat') as mock_pd_concat:
+             patch('st_app.update_manual_review') as mock_update_review:
+             # mock_pd_concat is removed as it's no longer used by fhrsid_lookup_logic
 
-            # Instantiate our custom MockSessionState
-            # It directly uses and modifies self.current_mock_session_state_dict
-            mock_st_global.session_state = MockSessionState(self.current_mock_session_state_dict)
-
-            # The MockSessionState class now handles the getitem, setitem, getattr, setattr logic.
-            # No need to set side_effects for these on mock_st_global.session_state anymore.
-
-            # Initialize attributes on MockSessionState instance for any values already in current_mock_session_state_dict.
-            # This ensures that if tests set initial values in self.current_mock_session_state_dict
-            # before _run_test_with_patches, they are reflected in the MockSessionState object.
-            # Note: The MockSessionState constructor already links it to self.current_mock_session_state_dict,
-            # so direct manipulation of self.current_mock_session_state_dict (like in some test setups)
-            # will be reflected. This loop might be redundant if all setup is done on current_mock_session_state_dict
-            # and not by trying to setattr on the session_state object before it's fully mocked.
-            # However, it's safer to ensure consistency.
-            for k, v in self.current_mock_session_state_dict.items():
-                setattr(mock_st_global.session_state, k, v)
-
+            # Assign our managed MockSessionState instance to the mock_st_global
+            mock_st_global.session_state = self.current_mock_session_state
 
             if mock_st_extras:
                 mock_st_extras(mock_st_global)
 
-            test_logic_func(mock_st_global, mock_read_from_bq, mock_update_review, mock_pd_concat)
+            # Pass only the relevant mocks to the test logic function
+            test_logic_func(mock_st_global, mock_read_from_bq, mock_update_review)
 
 
     # --- Tests for fhrsid_lookup_logic ---
@@ -101,48 +72,74 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
         sample_fhrsid = "12345"
         sample_df = pd.DataFrame({'fhrsid': [sample_fhrsid], 'data': ['test']})
         
-        def logic(mock_st, mock_read_from_bq, _, __):
+        # This test will directly manipulate self.current_mock_session_state
+        # which is used by mock_st_global.session_state
+
+        def logic(mock_st, mock_read_from_bq, _): # mock_pd_concat removed
             mock_read_from_bq.return_value = sample_df
 
-            fhrsid_lookup_logic(sample_fhrsid, "proj.dset.tbl", mock_st, mock_read_from_bq, None)
+            # Call fhrsid_lookup_logic without pd_concat
+            fhrsid_lookup_logic(sample_fhrsid, "proj.dset.tbl", mock_st, mock_read_from_bq)
 
-            self.assertIsNotNone(self.current_mock_session_state_dict['fhrsid_df'])
-            self.assertEqual(self.current_mock_session_state_dict['fhrsid_df']['fhrsid'].iloc[0], sample_fhrsid)
-            self.assertEqual(self.current_mock_session_state_dict['successful_fhrsids'], [sample_fhrsid])
+            self.assertTrue(not self.current_mock_session_state['fhrsid_df'].empty)
+            self.assertEqual(self.current_mock_session_state['fhrsid_df']['fhrsid'].iloc[0], sample_fhrsid)
+            self.assertEqual(self.current_mock_session_state['successful_fhrsids'], [sample_fhrsid])
             mock_st.success.assert_called_with(f"Data found for FHRSIDs: {sample_fhrsid}")
 
         self._run_test_with_patches(logic)
 
-    def test_fhrsid_lookup_clears_session_state_on_failure(self):
-        def logic(mock_st, mock_read_from_bq, _, __):
-            mock_read_from_bq.return_value = None
+    def test_fhrsid_lookup_no_data_found(self):
+        """ Test fhrsid_lookup_logic when read_from_bigquery returns an empty DataFrame. """
+        def logic(mock_st, mock_read_from_bq, _):
+            mock_read_from_bq.return_value = pd.DataFrame() # Empty DataFrame
 
-            self.current_mock_session_state_dict['fhrsid_df'] = pd.DataFrame({'fhrsid': ["old"], 'data': ['old_data']})
-            self.current_mock_session_state_dict['successful_fhrsids'] = ["old"]
-            # Ensure these are on the mock_st.session_state object too if getattr/setattr used by SUT
-            setattr(mock_st.session_state, 'fhrsid_df', self.current_mock_session_state_dict['fhrsid_df'])
-            setattr(mock_st.session_state, 'successful_fhrsids', self.current_mock_session_state_dict['successful_fhrsids'])
+            fhrsid_lookup_logic("unknown_fhrsid", "proj.dset.tbl", mock_st, mock_read_from_bq)
+
+            self.assertTrue(self.current_mock_session_state['fhrsid_df'].empty)
+            self.assertEqual(self.current_mock_session_state['successful_fhrsids'], [])
+            mock_st.warning.assert_called_with("No data found for any of the provided FHRSIDs: unknown_fhrsid.")
+            # Or, if multiple FHRSIDs were passed and none found, the message might be different.
+            # Adjust based on the exact message in fhrsid_lookup_logic.
+
+        self._run_test_with_patches(logic)
 
 
-            fhrsid_lookup_logic("123", "proj.dset.tbl", mock_st, mock_read_from_bq, None)
+    def test_fhrsid_lookup_handles_bq_error(self):
+        """ Test fhrsid_lookup_logic when read_from_bigquery raises BigQueryExecutionError. """
+        def logic(mock_st, mock_read_from_bq, _):
+            error_message = "BigQuery exploded during read"
+            mock_read_from_bq.side_effect = BigQueryExecutionError(error_message)
 
-            self.assertIsNone(self.current_mock_session_state_dict['fhrsid_df'])
-            self.assertEqual(self.current_mock_session_state_dict['successful_fhrsids'], [])
-            mock_st.warning.assert_called_with("No data found for the provided FHRSIDs: 123 in proj.dset.tbl, or an error occurred during lookup for all specified IDs.")
+            fhrsid_lookup_logic("123", "proj.dset.tbl", mock_st, mock_read_from_bq)
+
+            self.assertTrue(self.current_mock_session_state['fhrsid_df'].empty)
+            self.assertEqual(self.current_mock_session_state['successful_fhrsids'], [])
+            # Check that st.error was called with the specific error message from BigQueryExecutionError
+            mock_st.error.assert_called_with(f"BigQuery error during lookup for FHRSIDs 123: {error_message}")
         
         self._run_test_with_patches(logic)
 
-    def test_fhrsid_lookup_handles_bq_error(self):
-        def logic(mock_st, mock_read_from_bq, _, __):
-            mock_read_from_bq.side_effect = Exception("BigQuery exploded")
-
-            fhrsid_lookup_logic("123", "proj.dset.tbl", mock_st, mock_read_from_bq, None)
-
-            self.assertIsNone(self.current_mock_session_state_dict['fhrsid_df'])
-            self.assertEqual(self.current_mock_session_state_dict['successful_fhrsids'], [])
-            mock_st.warning.assert_called_with("No data found for the provided FHRSIDs: 123 in proj.dset.tbl, or an error occurred during lookup for all specified IDs.")
-
+    def test_fhrsid_lookup_input_validation_empty_fhrsid(self):
+        def logic(mock_st, mock_read_from_bq, _):
+            fhrsid_lookup_logic("", "proj.dset.tbl", mock_st, mock_read_from_bq)
+            mock_st.error.assert_called_with("Please enter one or more FHRSIDs.")
+            mock_read_from_bq.assert_not_called()
         self._run_test_with_patches(logic)
+
+    def test_fhrsid_lookup_input_validation_empty_bq_path(self):
+        def logic(mock_st, mock_read_from_bq, _):
+            fhrsid_lookup_logic("123", "", mock_st, mock_read_from_bq)
+            mock_st.error.assert_called_with("BigQuery Table Path is required.")
+            mock_read_from_bq.assert_not_called()
+        self._run_test_with_patches(logic)
+
+    def test_fhrsid_lookup_input_validation_invalid_bq_path_format(self):
+        def logic(mock_st, mock_read_from_bq, _):
+            fhrsid_lookup_logic("123", "proj.dset", mock_st, mock_read_from_bq) # Missing table_id
+            mock_st.error.assert_called_with("Invalid BigQuery Table Path format. Expected 'project.dataset.table'.")
+            mock_read_from_bq.assert_not_called()
+        self._run_test_with_patches(logic)
+
 
     def test_main_ui_update_workflow_success_single_fhrsid(self):
         fhrsid = "999"
@@ -175,7 +172,7 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
             # If only one FHRSID, selectbox is not called for FHRSID selection.
             # mock_st.selectbox implicitly won't be called or its call won't matter.
 
-        def logic(mock_st, mock_read_from_bq, mock_update_review, mock_pd_concat):
+        def logic(mock_st, mock_read_from_bq, mock_update_review): # mock_pd_concat removed
             mock_update_review.return_value = True
             refreshed_df = pd.DataFrame({'fhrsid': [fhrsid], 'manual_review': [new_review_value]})
             # This mock_read_from_bq will be used by the fhrsid_lookup_logic call during refresh
@@ -224,7 +221,7 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
             mock_st.text_input.side_effect = text_input_side_effect
             mock_st.multiselect.return_value = self.current_mock_session_state_dict['successful_fhrsids']
 
-        def logic(mock_st, mock_read_from_bq, mock_update_review, mock_pd_concat):
+        def logic(mock_st, mock_read_from_bq, mock_update_review): # mock_pd_concat removed
             mock_update_review.return_value = False
             initial_read_call_count = mock_read_from_bq.call_count
 


### PR DESCRIPTION
This commit refactors the FHRSID lookup mechanism.

Key changes:
- I integrated the `pandas-gbq` library for BigQuery interactions in `bq_utils.py`, specifically within the `read_from_bigquery` function.
- I simplified `fhrsid_lookup_logic` in `st_app.py` by removing the loop for individual FHRSID lookups. It now makes a single batch call to `read_from_bigquery`.
- `read_from_bigquery` now returns an empty DataFrame if no results are found, streamlining client-side handling.
- I updated unit tests in `test_bq_utils.py` and `test_st_app.py` to reflect these changes, including mocking `pandas_gbq` and adjusting tests for the modified application logic.
- I added `pandas-gbq` to `requirements.txt`.

The Streamlit application's FHRSID lookup feature now uses a more direct approach for fetching data from BigQuery, leveraging `pandas-gbq` for this purpose.