### PR TITLE
Fix: Correct assertions in test_st_app.py

### DIFF
--- a/test_st_app.py
+++ b/test_st_app.py
@@ -93,11 +93,12 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
         def logic(mock_st, mock_read_from_bq, _):
             mock_read_from_bq.return_value = pd.DataFrame() # Empty DataFrame
 
-            fhrsid_lookup_logic("unknown_fhrsid", "proj.dset.tbl", mock_st, mock_read_from_bq)
+            numeric_fhrsid_for_test = "00000" # Or any other valid numeric string
+            fhrsid_lookup_logic(numeric_fhrsid_for_test, "proj.dset.tbl", mock_st, mock_read_from_bq)
 
             self.assertTrue(self.current_mock_session_state['fhrsid_df'].empty)
             self.assertEqual(self.current_mock_session_state['successful_fhrsids'], [])
-            mock_st.warning.assert_called_with("No data found for any of the provided FHRSIDs: unknown_fhrsid.")
+            mock_st.warning.assert_called_with(f"No data found for any of the provided FHRSIDs: {numeric_fhrsid_for_test}.")
             # Or, if multiple FHRSIDs were passed and none found, the message might be different.
             # Adjust based on the exact message in fhrsid_lookup_logic.
 
@@ -188,7 +189,7 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
                 table_id="tbl"
             )
             # fhrsid_lookup_logic (which calls read_from_bigquery) is called for refresh
-            mock_read_from_bq.assert_called_with([fhrsid], "proj", "dset", "tbl")
+            mock_read_from_bq.assert_called_with([int(fhrsid)], "proj", "dset", "tbl")
             mock_st.success.assert_any_call(f"Manual review updated for FHRSIDs: {fhrsid}. Refreshing data...")
             mock_st.rerun.assert_called_once()
             self.assertEqual(self.current_mock_session_state['fhrsid_df']['manual_review'].iloc[0], new_review_value)


### PR DESCRIPTION
This commit addresses two failing tests in test_st_app.py:

1.  test_fhrsid_lookup_no_data_found: The test was failing because it used a non-numeric FHRSID ("unknown_fhrsid"), which caused an early exit in `fhrsid_lookup_logic` after an `st.error` call, preventing the expected `st.warning` call from being reached. The test has been updated to use a numeric FHRSID string ("00000") that would allow the logic to proceed to the point where an empty DataFrame is returned and the specific "No data found for any of the provided FHRSIDs..." warning is triggered.

2.  test_main_ui_update_workflow_success_single_fhrsid: The test was failing because the assertion for `mock_read_from_bq` expected a list of FHRSID strings `['999']`. However, the `fhrsid_lookup_logic` function correctly converts FHRSIDs to integers before calling `read_from_bigquery`. The assertion has been updated to expect a list of integers `[999]`.

All tests now pass after these changes.