### PR TITLE
Fix FHRSID type error in BigQuery lookup

### DIFF
--- a/bq_utils.py
+++ b/bq_utils.py
@@ -97,7 +97,7 @@ def write_to_bigquery(df: pd.DataFrame, project_id: str, dataset_id: str, table_
         st.error(f"Error writing data to BigQuery table {table_ref_str}: {e}")
         return False
 
-def read_from_bigquery(fhrsid_list: List[int], project_id: str, dataset_id: str, table_id: str) -> pd.DataFrame: # Changed return type
+def read_from_bigquery(fhrsid_list: List[str], project_id: str, dataset_id: str, table_id: str) -> pd.DataFrame: # Changed return type
     """
     Reads data from a BigQuery table for a list of FHRSIDs using pandas-gbq.
 
@@ -121,7 +121,7 @@ def read_from_bigquery(fhrsid_list: List[int], project_id: str, dataset_id: str,
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'arrayType': {'type': 'INT64'}},
+                    'parameterType': {'arrayType': {'type': 'STRING'}},
                     'parameterValue': {'arrayValues': [{'value': f_id} for f_id in fhrsid_list]}
                 }
             ]

--- a/test_bq_utils.py
+++ b/test_bq_utils.py
@@ -17,7 +17,7 @@ def test_read_from_bigquery_success(mock_read_gbq):
     expected_df = pd.DataFrame({'fhrsid': [123], 'data': ['test data']}) # Assuming fhrsid in DataFrame could also be int
     mock_read_gbq.return_value = expected_df
 
-    fhrsid_list = [123, 456] # Changed to list of integers
+    fhrsid_list = ['123', '456'] # Changed to list of integers
     project_id = "test-project"
     dataset_id = "test-dataset"
     table_id = "test-table"
@@ -28,7 +28,7 @@ def test_read_from_bigquery_success(mock_read_gbq):
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'arrayType': {'type': 'INT64'}}, # Changed to INT64
+                    'parameterType': {'arrayType': {'type': 'STRING'}}, # Changed to INT64
                     'parameterValue': {'arrayValues': [{'value': f_id} for f_id in fhrsid_list]}
                 }
             ]


### PR DESCRIPTION
The read_from_bigquery function was sending FHRSIDs as INT64, but the BigQuery table expects STRING. This caused a type mismatch error.

This commit changes the function to send FHRSIDs as STRING and updates the corresponding test case.