### PR TITLE
Fix: Handle FHRSIDs as strings in BigQuery lookup

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -85,22 +85,23 @@ def fhrsid_lookup_logic(fhrsid_input_str: str, bq_table_lookup_input_str: str, s
             st_object.error("Please enter valid FHRSIDs.")
             return
 
-        # Convert FHRSIDs to integers and handle errors
-        fhrsid_list_integers = []
+        # Validate FHRSIDs as numbers but store them as strings
+        fhrsid_list_validated_strings = []
         for f_id_str in fhrsid_list_requested:
             try:
-                fhrsid_list_integers.append(int(f_id_str))
+                int(f_id_str) # Validate that f_id_str is a number
+                fhrsid_list_validated_strings.append(f_id_str) # Store the original string
             except ValueError:
                 st_object.error(f"Invalid FHRSID: '{f_id_str}' is not a valid number. Please enter numeric FHRSIDs only.")
                 return # Stop processing
 
-        st_object.info(f"FHRSID Lookup: Attempting to retrieve data for {len(fhrsid_list_integers)} FHRSID(s): {', '.join(fhrsid_list_requested)} in a single batch.")
+        st_object.info(f"FHRSID Lookup: Attempting to retrieve data for {len(fhrsid_list_validated_strings)} FHRSID(s): {', '.join(fhrsid_list_requested)} in a single batch.")
 
         final_df = None # Explicitly initialize final_df to None
         try:
-            # Call read_from_bq_func once with the entire list of integers
+            # Call read_from_bq_func once with the entire list of validated strings
             # read_from_bigquery now returns an empty DataFrame if no records are found, or raises an error.
-            final_df = read_from_bq_func(fhrsid_list_integers, project_id, dataset_id, table_id)
+            final_df = read_from_bq_func(fhrsid_list_validated_strings, project_id, dataset_id, table_id)
         except BigQueryExecutionError as e: # Catching specific BQ execution errors
             st_object.error(f"BigQuery error during lookup for FHRSIDs {', '.join(fhrsid_list_requested)}: {e}") # Log original string list
             # DataFrameConversionError is less likely here as pandas-gbq handles conversion,


### PR DESCRIPTION
The FHRSID lookup functionality was encountering a TypeError (sequence item 0: expected str instance, int found) because integers were being passed to a BigQuery operation that expected strings for FHRSID values in an UNNEST operation.

This commit addresses the issue by:
1. Modifying `st_app.py` (`fhrsid_lookup_logic`):
   - FHRSIDs are now validated to be numeric but are maintained as strings when passed to the `read_from_bigquery` function.
   - The variable `fhrsid_list_integers` was renamed to `fhrsid_list_validated_strings` to reflect this change.

2. Verifying `bq_utils.py` (`read_from_bigquery`):
   - Confirmed that the function expects `List[str]` for FHRSIDs and correctly uses `{'arrayType': {'type': 'STRING'}}` in its BigQuery query parameters. No code changes were needed here, but a docstring was slightly updated for clarity.

3. Updating Unit Tests:
   - Tests in `test_st_app.py` for `fhrsid_lookup_logic` were updated and added to ensure that `read_from_bigquery` is called with a list of strings under various input conditions (single, multiple, spaces, non-numeric).
   - Tests in `test_bq_utils.py` for `read_from_bigquery` were updated to use string FHRSIDs and verify correct interaction with `pandas_gbq.read_gbq`, including parameter configuration.

The fix ensures that FHRSIDs are consistently treated as strings where required by BigQuery, resolving the TypeError and maintaining support for single and colon-separated FHRSID inputs.