### PR TITLE
Refactor: Use comma as delimiter for FHRSID lookup

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -79,8 +79,8 @@ def fhrsid_lookup_logic(fhrsid_input_str: str, bq_table_lookup_input_str: str, s
             st_object.error("Invalid BigQuery Table Path format. Each part of 'project.dataset.table' must be non-empty.")
             return
 
-        fhrsid_list_requested = [fhrsid.strip() for fhrsid in fhrsid_input_str.split(':') if fhrsid.strip()]
-        fhrsid_list_requested = [f_id for f_id in fhrsid_list_requested if f_id] # Ensure no empty strings if input was like "123::456"
+        fhrsid_list_requested = [fhrsid.strip() for fhrsid in fhrsid_input_str.split(',') if fhrsid.strip()]
+        fhrsid_list_requested = [f_id for f_id in fhrsid_list_requested if f_id] # Ensure no empty strings if input was like "123,,456"
         if not fhrsid_list_requested:
             st_object.error("Please enter valid FHRSIDs.")
             return
@@ -337,7 +337,7 @@ def main_ui():
         st.subheader("FHRSID Lookup")
         # Use session state to retain input values across reruns
         st.session_state.fhrsid_input_str_ui = st.text_input(
-            "Enter FHRSIDs (colon-separated):",
+            "Enter FHRSIDs (comma-separated):",
             value=st.session_state.fhrsid_input_str_ui
         )
         st.session_state.bq_table_lookup_input_str_ui = st.text_input(

--- a/test_st_app.py
+++ b/test_st_app.py
@@ -92,9 +92,9 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
         self._run_test_with_patches(logic)
 
     def test_fhrsid_lookup_multiple_valid_fhrsids(self):
-        """Test with multiple valid FHRSIDs, colon-separated."""
+        """Test with multiple valid FHRSIDs, comma-separated."""
         def logic(mock_st, mock_read_from_bq, _):
-            fhrsid_input = "123:456:789"
+            fhrsid_input = "123,456,789"
             expected_fhrsid_list = ["123", "456", "789"]
             mock_read_from_bq.return_value = pd.DataFrame({'fhrsid': expected_fhrsid_list}) # Simulate finding all
 
@@ -109,7 +109,7 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
     def test_fhrsid_lookup_fhrsids_with_spaces(self):
         """Test FHRSIDs with leading/trailing spaces."""
         def logic(mock_st, mock_read_from_bq, _):
-            fhrsid_input = " 123 : 456 "
+            fhrsid_input = " 123 , 456 "
             expected_fhrsid_list = ["123", "456"]
             mock_read_from_bq.return_value = pd.DataFrame({'fhrsid': expected_fhrsid_list})
 
@@ -121,9 +121,9 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
         self._run_test_with_patches(logic)
 
     def test_fhrsid_lookup_empty_fhrsid_parts(self):
-        """Test with empty parts in FHRSID string due to extra colons."""
+        """Test with empty parts in FHRSID string due to extra commas."""
         def logic(mock_st, mock_read_from_bq, _):
-            fhrsid_input = "123::456:" # Trailing colon and empty part
+            fhrsid_input = "123,,456," # Trailing comma and empty part
             expected_fhrsid_list = ["123", "456"]
             mock_read_from_bq.return_value = pd.DataFrame({'fhrsid': expected_fhrsid_list})
 
@@ -137,7 +137,7 @@ class TestFhrsidLookupAndUpdateWorkflow(unittest.TestCase):
     def test_fhrsid_lookup_non_numeric_fhrsid(self):
         """Test with a non-numeric FHRSID in the list."""
         def logic(mock_st, mock_read_from_bq, _):
-            fhrsid_input = "123:abc:456"
+            fhrsid_input = "123,abc,456"
 
             fhrsid_lookup_logic(fhrsid_input, "proj.dset.tbl", mock_st, mock_read_from_bq)
 


### PR DESCRIPTION
The FHRSID lookup functionality has been updated to accept a comma-separated list of IDs instead of colon-separated.

This change involves:
- Modifying the `fhrsid_lookup_logic` function in `st_app.py` to split the input string by commas.
- Updating the UI text in the `main_ui` function in `st_app.py` to prompt you for comma-separated FHRSIDs.
- Updating relevant tests in `test_st_app.py` to use comma-separated FHRSIDs and ensure they pass.