### PR TITLE
Fix: Correct BigQuery array parameter type structure

### DIFF
--- a/bq_utils.py
+++ b/bq_utils.py
@@ -121,7 +121,7 @@ def read_from_bigquery(fhrsid_list: List[str], project_id: str, dataset_id: str,
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'arrayType': {'type': 'STRING'}},
+                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}},
                     'parameterValue': {'arrayValues': [{'value': f_id} for f_id in fhrsid_list]}
                 }
             ]

--- a/test_bq_utils.py
+++ b/test_bq_utils.py
@@ -28,7 +28,7 @@ def test_read_from_bigquery_success(mock_read_gbq):
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'arrayType': {'type': 'STRING'}}, # Correctly STRING
+                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}}, # Correctly STRING
                     'parameterValue': {'arrayValues': [{'value': '123'}, {'value': '456'}]} # Explicitly string values
                 }
             ]
@@ -60,7 +60,7 @@ def test_read_from_bigquery_empty_result(mock_read_gbq):
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'arrayType': {'type': 'STRING'}},
+                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}},
                     'parameterValue': {'arrayValues': [{'value': '789'}]}
                 }
             ]
@@ -92,7 +92,7 @@ def test_read_from_bigquery_empty_input_list(mock_read_gbq):
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'arrayType': {'type': 'STRING'}},
+                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}},
                     'parameterValue': {'arrayValues': []} # Expect empty arrayValues
                 }
             ]


### PR DESCRIPTION
The 'parameterType' for array parameters in the `read_from_bigquery` function in `bq_utils.py` was missing the outer `{'type': 'ARRAY'}` wrapper. This caused an "Invalid query parameter type" error when making calls to BigQuery using pandas-gbq.

This change updates the `parameterType` to the correct structure: `{'type': 'ARRAY', 'arrayType': {'type': 'STRING'}}` as per the Google BigQuery API documentation.

The corresponding unit tests in `test_bq_utils.py` have also been updated to reflect this corrected structure in their expected configurations for mocked calls.