### PR TITLE
Refactor: Remove 'gemini_insights' column from master data

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -56,8 +56,6 @@ def load_master_data(uri: str, load_json_func: Callable[[str], Any]) -> List[Dic
         for restaurant in loaded_data:
             if isinstance(restaurant, dict) and restaurant.get("manual_review") is None:
                 restaurant["manual_review"] = "not reviewed"
-            if isinstance(restaurant, dict) and restaurant.get("gemini_insights") is None:
-                restaurant["gemini_insights"] = None
         return loaded_data
     else:
         st.warning(f"Data loaded from {uri} is not in the expected list format. Type found: {type(loaded_data)}. Proceeding with empty master restaurant data.")
@@ -91,7 +89,6 @@ def process_and_update_master_data(master_data: List[Dict[str, Any]], api_data: 
             if api_establishment['FHRSID'] not in existing_fhrsid_set:
                 api_establishment['first_seen'] = today_date
                 api_establishment['manual_review'] = "not reviewed"
-                api_establishment['gemini_insights'] = None
                 master_data.append(api_establishment)
                 existing_fhrsid_set.add(api_establishment['FHRSID'])
                 new_restaurants_added_count += 1


### PR DESCRIPTION
This commit removes the 'gemini_insights' column and its associated logic from the data processing pipeline.

Changes made:
- Removed the initialization of 'gemini_insights' to None in the `load_master_data` function in `data_processing.py`.
- Removed the initialization of 'gemini_insights' to None for new records in the `process_and_update_master_data` function in `data_processing.py`.
- Updated tests in `test_data_processing.py` to reflect the removal of the 'gemini_insights' column. This included:
    - Renaming `test_load_master_data_initializes_gemini_insights_to_none` to `test_load_master_data_initializes_manual_review` and adjusting its assertions.
    - Renaming `test_process_and_update_master_data_initializes_gemini_insights_for_new_records` to `test_process_and_update_master_data_initializes_fields_for_new_records` and removing the 'gemini_insights' assertion.
    - Removing 'gemini_insights' from test data and assertions in `test_process_and_update_master_data_no_new_records`.
- Ensured all tests pass after these modifications.