### PR TITLE
Fix: Ensure FHRSID is string before BigQuery append

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -93,8 +93,11 @@ def process_and_update_master_data(master_data: List[Dict[str, Any]], api_data: 
 
     for api_establishment in api_establishments:
         if isinstance(api_establishment, dict) and 'FHRSID' in api_establishment:
-            if api_establishment['FHRSID'] not in existing_fhrsid_set:
-                # Add required fields to the new establishment
+            # Convert FHRSID to string
+            fhrsid_str = str(api_establishment['FHRSID'])
+            if fhrsid_str not in existing_fhrsid_set:
+                # Use the string version of FHRSID
+                api_establishment['FHRSID'] = fhrsid_str
                 api_establishment['first_seen'] = today_date
                 api_establishment['manual_review'] = "not reviewed"
                 newly_added_restaurants.append(api_establishment)


### PR DESCRIPTION
The BigQuery `fsa_master` table expects the `fhrsid` field to be of type STRING. Previously, if your input API data contained `FHRSID` as an integer, this type could be preserved, leading to a schema mismatch error (400 Bad Request) when appending new records: "Field fhrsid has changed type from STRING to INTEGER".

This commit addresses the issue by:
1. Explicitly converting the `FHRSID` field to a string in the `process_and_update_master_data` function within `data_processing.py`. This ensures that all new establishment records prepared for BigQuery will have `FHRSID` as a string.
2. Adding a new unit test (`test_fhrsid_is_string_after_processing`) in `test_data_processing.py`. This test verifies that an integer `FHRSID` from the API data is correctly converted to its string representation during data processing.

These changes ensure that the data appended to BigQuery conforms to the target table's schema, preventing the type mismatch error.