### PR TITLE
Fix: Ensure FHRSID is an integer for BigQuery operations

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -93,11 +93,17 @@ def process_and_update_master_data(master_data: List[Dict[str, Any]], api_data: 
 
     for api_establishment in api_establishments:
         if isinstance(api_establishment, dict) and 'FHRSID' in api_establishment:
-            # Convert FHRSID to string
-            fhrsid_str = str(api_establishment['FHRSID'])
-            if fhrsid_str not in existing_fhrsid_set:
-                # Use the string version of FHRSID
-                api_establishment['FHRSID'] = fhrsid_str
+            # Ensure FHRSID is an integer for comparison and storage
+            fhrsid_int = api_establishment['FHRSID'] # Assuming FHRSID from API is already an int or convertible
+            if not isinstance(fhrsid_int, int):
+                try:
+                    fhrsid_int = int(fhrsid_int)
+                except (ValueError, TypeError):
+                    st.warning(f"Could not convert FHRSID '{fhrsid_int}' to int for establishment: {api_establishment.get('BusinessName', 'N/A')}. Skipping this record.")
+                    continue # Skip if FHRSID cannot be an integer
+
+            if fhrsid_int not in existing_fhrsid_set:
+                api_establishment['FHRSID'] = fhrsid_int # Ensure the integer version is stored
                 api_establishment['first_seen'] = today_date
                 api_establishment['manual_review'] = "not reviewed"
                 newly_added_restaurants.append(api_establishment)


### PR DESCRIPTION
The FHRSID field was being incorrectly converted to a string before being sent to BigQuery, while BigQuery expected an INT64. This caused errors during data append operations.

This commit addresses the issue by:
- Removing the string conversion of FHRSID in `data_processing.py`. FHRSID is now processed as an integer. Added robustness for cases where FHRSID might not be an integer in the raw API data.
- Removing the explicit string casting of the `fhrsid` column in `bq_utils.py`'s `append_to_bigquery` and `write_to_bigquery` functions.
- Updating `bq_utils.py` functions (`read_from_bigquery`, `update_manual_review`) to use INT64 for `fhrsid_list` query parameters.
- Adjusting type hints for `fhrsid_list` to `List[int]`.
- Updating all relevant unit tests in `test_data_processing.py` and `test_bq_utils.py` to reflect FHRSID as an integer. Test data, assertions, and mock configurations have been updated accordingly. All tests pass with these changes.