### PR TITLE
Fix: Ensure fhrsid is consistently treated as STRING

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -87,23 +87,20 @@ def process_and_update_master_data(master_data: List[Dict[str, Any]], api_data: 
     elif not api_establishments: 
          st.info("API response contained no establishments in 'EstablishmentDetail'.")
 
-    existing_fhrsid_set = {est['FHRSID'] for est in master_data if isinstance(est, dict) and 'FHRSID' in est}
+    # Ensure FHRSIDs in existing_fhrsid_set are strings
+    existing_fhrsid_set = {str(est['FHRSID']) for est in master_data if isinstance(est, dict) and 'FHRSID' in est}
     today_date = datetime.now().strftime("%Y-%m-%d")
     newly_added_restaurants: List[Dict[str, Any]] = []
 
     for api_establishment in api_establishments:
         if isinstance(api_establishment, dict) and 'FHRSID' in api_establishment:
-            # Ensure FHRSID is an integer for comparison and storage
-            fhrsid_int = api_establishment['FHRSID'] # Assuming FHRSID from API is already an int or convertible
-            if not isinstance(fhrsid_int, int):
-                try:
-                    fhrsid_int = int(fhrsid_int)
-                except (ValueError, TypeError):
-                    st.warning(f"Could not convert FHRSID '{fhrsid_int}' to int for establishment: {api_establishment.get('BusinessName', 'N/A')}. Skipping this record.")
-                    continue # Skip if FHRSID cannot be an integer
+            # Ensure FHRSID is treated as a string
+            fhrsid_str = str(api_establishment['FHRSID'])
 
-            if fhrsid_int not in existing_fhrsid_set:
-                api_establishment['FHRSID'] = fhrsid_int # Ensure the integer version is stored
+            # FHRSID is now a string, ensure it's stored as such
+            api_establishment['FHRSID'] = fhrsid_str
+
+            if fhrsid_str not in existing_fhrsid_set:
                 api_establishment['first_seen'] = today_date
                 api_establishment['manual_review'] = "not reviewed"
                 newly_added_restaurants.append(api_establishment)

--- a/test_bq_utils.py
+++ b/test_bq_utils.py
@@ -103,10 +103,10 @@ def test_load_all_data_from_bq_generic_exception(mock_print, mock_read_gbq):
 @patch('bq_utils.pandas_gbq.read_gbq')
 def test_read_from_bigquery_success(mock_read_gbq):
     """Test successful data retrieval with pandas_gbq.read_gbq."""
-    expected_df = pd.DataFrame({'fhrsid': [123], 'data': ['test data']})
+    expected_df = pd.DataFrame({'fhrsid': ["123"], 'data': ['test data']}) # FHRSID is string
     mock_read_gbq.return_value = expected_df
 
-    fhrsid_list = [123, 456] # Changed to list of integers
+    fhrsid_list = ["123", "456"] # List of strings
     project_id = "test-project"
     dataset_id = "test-dataset"
     table_id = "test-table"
@@ -117,8 +117,8 @@ def test_read_from_bigquery_success(mock_read_gbq):
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'INT64'}}, # Changed to INT64
-                    'parameterValue': {'arrayValues': [{'value': 123}, {'value': 456}]} # Changed to integers
+                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}}, # Changed to STRING
+                    'parameterValue': {'arrayValues': [{'value': "123"}, {'value': "456"}]} # List of strings
                 }
             ]
         }
@@ -138,7 +138,7 @@ def test_read_from_bigquery_empty_result(mock_read_gbq):
     """Test retrieval of an empty DataFrame when no data is found for non-empty input list."""
     mock_read_gbq.return_value = pd.DataFrame()
 
-    fhrsid_list = [789] # Changed to list of integers
+    fhrsid_list = ["789"] # List of strings
     project_id = "test-project"
     dataset_id = "test-dataset"
     table_id = "test-table"
@@ -149,8 +149,8 @@ def test_read_from_bigquery_empty_result(mock_read_gbq):
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'INT64'}}, # Changed to INT64
-                    'parameterValue': {'arrayValues': [{'value': 789}]} # Changed to integer
+                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}}, # Changed to STRING
+                    'parameterValue': {'arrayValues': [{'value': "789"}]} # List of strings
                 }
             ]
         }
@@ -181,7 +181,7 @@ def test_read_from_bigquery_empty_input_list(mock_read_gbq):
             'queryParameters': [
                 {
                     'name': 'fhrsid_list',
-                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'INT64'}}, # Changed to INT64
+                    'parameterType': {'type': 'ARRAY', 'arrayType': {'type': 'STRING'}}, # Changed to STRING
                     'parameterValue': {'arrayValues': []} # Remains empty, type change is key
                 }
             ]
@@ -202,7 +202,7 @@ def test_read_from_bigquery_raises_bigqueryexecutionerror_on_generic_exception(m
     """Test that BigQueryExecutionError is raised for generic exceptions from read_gbq."""
     mock_read_gbq.side_effect = Exception("Simulated generic error from read_gbq")
 
-    fhrsid_list = [101] # Changed to list of integers
+    fhrsid_list = ["101"] # List of strings
     project_id = "test-project"
     dataset_id = "test-dataset"
     table_id = "test-table"
@@ -218,7 +218,7 @@ if GenericGBQException:
         """Test that BigQueryExecutionError is raised for pandas_gbq.gbq.GenericGBQException."""
         mock_read_gbq.side_effect = GenericGBQException("Simulated GenericGBQException")
 
-        fhrsid_list = [102] # Changed to list of integers
+        fhrsid_list = ["102"] # List of strings
         project_id = "test-project"
         dataset_id = "test-dataset"
         table_id = "test-table"
@@ -233,7 +233,7 @@ def test_read_from_bigquery_raises_bigqueryexecutionerror_on_googleclouderror(mo
     """Test that BigQueryExecutionError is raised for google.cloud.exceptions.GoogleCloudError."""
     mock_read_gbq.side_effect = exceptions.GoogleCloudError("Simulated GoogleCloudError")
 
-    fhrsid_list = [103] # Changed to list of integers
+    fhrsid_list = ["103"] # List of strings
     project_id = "test-project"
     dataset_id = "test-dataset"
     table_id = "test-table"
@@ -254,7 +254,7 @@ def test_update_manual_review_batch_success(mock_bq_client_constructor, mock_st)
     mock_bq_client_instance.query.return_value = mock_query_job
     mock_query_job.result.return_value = None
 
-    fhrsid_list = [101, 102, 103] # Changed to list of integers
+    fhrsid_list = ["101", "102", "103"] # List of strings
     manual_review_value = "BatchApproved"
     project_id = "batch-proj"
     dataset_id = "batch-dset"
@@ -278,7 +278,7 @@ def test_update_manual_review_batch_success(mock_bq_client_constructor, mock_st)
 
     expected_params = [
         bigquery.ScalarQueryParameter("manual_review_value", "STRING", manual_review_value),
-        bigquery.ArrayQueryParameter("fhrsid_list", "INT64", fhrsid_list), # Changed to INT64
+        bigquery.ArrayQueryParameter("fhrsid_list", "STRING", fhrsid_list), # Changed to STRING
     ]
 
     # Ensure job_config.query_parameters is not None before checking its length
@@ -317,7 +317,7 @@ def test_update_manual_review_batch_bq_error(mock_bq_client_constructor, mock_st
     mock_bq_client_instance.query.return_value = mock_query_job
     mock_query_job.result.side_effect = exceptions.GoogleCloudError("Test BQ API Error on batch update")
 
-    fhrsid_list = [201, 202] # Changed to list of integers
+    fhrsid_list = ["201", "202"] # List of strings
     manual_review_value = "BatchRejected"
     project_id = "batch-proj"
     dataset_id = "batch-dset"
@@ -367,20 +367,21 @@ def test_write_to_bigquery_newratingpending_conversion_and_fhrsid_type(mock_bq_c
 
     original_col_name = 'NewRatingPending'
     sanitized_col_name = sanitize_column_name(original_col_name)
-    sanitized_fhrsid_col = sanitize_column_name('FHRSID')
+    sanitized_fhrsid_col = sanitize_column_name('FHRSID') # This will be 'fhrsid'
 
     data = {
-        'FHRSID': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], # FHRSID is int
+        'FHRSID': ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"], # FHRSID is string
         'BusinessName': ['Cafe A', 'Cafe B', 'Cafe C', 'Cafe D', 'Cafe E', 'Cafe F', 'Cafe G', 'Cafe H', 'Cafe I', 'Cafe J', 'Cafe K', 'Cafe L'],
         original_col_name: ["true", "False", "TRUE", "false", "TrUe", "FaLsE", "other", "", None, pd.NA, " existing_true ", " existing_false "]
     }
     df = pd.DataFrame(data)
-    # Ensure FHRSID column is integer type, if it got mixed up
-    df['FHRSID'] = df['FHRSID'].astype(int)
+    # Ensure FHRSID column is string type
+    df['FHRSID'] = df['FHRSID'].astype(str)
 
     columns_to_select = ['FHRSID', 'BusinessName', original_col_name]
+    # Schema now expects STRING for fhrsid
     bq_schema = [
-        bigquery.SchemaField(sanitized_fhrsid_col, 'INTEGER'), # Schema expects INTEGER for FHRSID
+        bigquery.SchemaField(sanitized_fhrsid_col, 'STRING'),
         bigquery.SchemaField(sanitize_column_name('BusinessName'), 'STRING'),
         bigquery.SchemaField(sanitized_col_name, 'BOOLEAN')
     ]
@@ -404,10 +405,12 @@ def test_write_to_bigquery_newratingpending_conversion_and_fhrsid_type(mock_bq_c
     assert loaded_df_call is not None, "load_table_from_dataframe was not called with any arguments"
     loaded_df = loaded_df_call[0][0]
 
-    # Check FHRSID type
-    assert sanitized_fhrsid_col in loaded_df.columns, f"Column '{sanitized_fhrsid_col}' not found."
-    assert pd.api.types.is_integer_dtype(loaded_df[sanitized_fhrsid_col]), \
-        f"FHRSID column in loaded_df should be integer, got {loaded_df[sanitized_fhrsid_col].dtype}"
+    # Check FHRSID type after sanitization (should be 'fhrsid')
+    # The key in loaded_df.columns will be the sanitized version, e.g., 'fhrsid'
+    actual_sanitized_fhrsid_col_in_df = sanitize_column_name('FHRSID')
+    assert actual_sanitized_fhrsid_col_in_df in loaded_df.columns, f"Column '{actual_sanitized_fhrsid_col_in_df}' not found. Columns: {loaded_df.columns}"
+    assert pd.api.types.is_string_dtype(loaded_df[actual_sanitized_fhrsid_col_in_df]), \
+        f"FHRSID column '{actual_sanitized_fhrsid_col_in_df}' in loaded_df should be string, got {loaded_df[actual_sanitized_fhrsid_col_in_df].dtype}"
 
     expected_newratingpending_values = [
         True, False, True, False, True, False,
@@ -443,16 +446,17 @@ def test_write_to_bigquery_includes_gemini_insights_in_schema(mock_bq_client_con
     mock_load_job.result.return_value = None
 
     data = {
-        'FHRSID': [1],
+        'FHRSID': ["1"], # FHRSID is string
         'BusinessName': ['Test Cafe'],
         'gemini_insights': [None],
         'manual_review': ['reviewed'],
         'NewRatingPending': ['false']
     }
     df = pd.DataFrame(data)
+    df['FHRSID'] = df['FHRSID'].astype(str) # Ensure string type
     columns_to_select = ['FHRSID', 'BusinessName', 'gemini_insights', 'manual_review', 'NewRatingPending']
     expected_bq_schema_passed_to_function = [
-        bigquery.SchemaField(sanitize_column_name('FHRSID'), 'INTEGER'),
+        bigquery.SchemaField(sanitize_column_name('FHRSID'), 'STRING'), # FHRSID is STRING
         bigquery.SchemaField(sanitize_column_name('BusinessName'), 'STRING'),
         bigquery.SchemaField(sanitize_column_name('gemini_insights'), 'STRING', mode='NULLABLE'),
         bigquery.SchemaField(sanitize_column_name('manual_review'), 'STRING', mode='NULLABLE'),
@@ -497,13 +501,14 @@ class TestAppendToBigQuery(unittest.TestCase): # Changed to use unittest.TestCas
         mock_job.result.return_value = None
 
         data = {
-            'fhrsid': [1, 2],
+            'fhrsid': ["1", "2"], # fhrsid is string
             'businessname': ['Restaurant A', 'Restaurant B'],
             'newratingpending': ['false', 'true'],
             'geocode_latitude': ['51.0', '52.0'],
             'geocode_longitude': ['-0.1', '-0.2']
         }
         df = pd.DataFrame(data)
+        df['fhrsid'] = df['fhrsid'].astype(str) # Ensure string type
 
         # append_to_bigquery expects df column names to be already sanitized
         # and matching the schema field names.
@@ -511,7 +516,7 @@ class TestAppendToBigQuery(unittest.TestCase): # Changed to use unittest.TestCas
 
 
         schema = [
-            bigquery.SchemaField(sanitize_column_name('fhrsid'), 'INTEGER'),
+            bigquery.SchemaField(sanitize_column_name('fhrsid'), 'STRING'), # fhrsid is STRING
             bigquery.SchemaField(sanitize_column_name('businessname'), 'STRING'),
             bigquery.SchemaField(sanitize_column_name('newratingpending'), 'BOOLEAN'),
             bigquery.SchemaField(sanitize_column_name('geocode_latitude'), 'FLOAT'),
@@ -539,6 +544,8 @@ class TestAppendToBigQuery(unittest.TestCase): # Changed to use unittest.TestCas
         self.assertEqual(job_config.write_disposition, bigquery.WriteDisposition.WRITE_APPEND)
         self.assertEqual(job_config.schema, schema)
 
+        # Assert fhrsid is string type in the DataFrame passed to BQ
+        self.assertTrue(pd.api.types.is_string_dtype(called_df[sanitize_column_name('fhrsid')]))
         self.assertTrue(pd.api.types.is_bool_dtype(called_df[sanitize_column_name('newratingpending')]))
         self.assertTrue(pd.api.types.is_numeric_dtype(called_df[sanitize_column_name('geocode_latitude')]))
         self.assertTrue(pd.api.types.is_numeric_dtype(called_df[sanitize_column_name('geocode_longitude')]))
@@ -619,26 +626,26 @@ class TestAppendToBigQuery(unittest.TestCase): # Changed to use unittest.TestCas
 
     @patch('bq_utils.st') # Mock streamlit for status messages
     @patch('bq_utils.bigquery.Client')
-    def test_append_to_bigquery_fhrsid_is_integer(self, mock_bq_client_constructor, mock_st): # Renamed test
-        """Test that fhrsid column is handled as integer for BQ load when schema is INTEGER."""
+    def test_append_to_bigquery_fhrsid_is_string(self, mock_bq_client_constructor, mock_st): # Renamed test
+        """Test that fhrsid column is handled as string for BQ load when schema is STRING."""
         mock_bq_client_instance = mock_bq_client_constructor.return_value
         mock_load_job = MagicMock()
         mock_bq_client_instance.load_table_from_dataframe.return_value = mock_load_job
         mock_load_job.result.return_value = None
 
-        # Sample DataFrame with fhrsid as integers
+        # Sample DataFrame with fhrsid as strings
         sample_data = {
-            'fhrsid': [123, 456, 789], # Already integers
+            'fhrsid': ["123", "456", "789"], # String fhrsids
             'another_col': ['value1', 'value2', 'value3']
         }
         sample_df = pd.DataFrame(sample_data)
-        # Ensure fhrsid is int, in case DataFrame init does something unexpected
-        sample_df['fhrsid'] = sample_df['fhrsid'].astype(int)
+        # Ensure fhrsid is string
+        sample_df['fhrsid'] = sample_df['fhrsid'].astype(str)
 
 
-        # Schema now defines fhrsid as INTEGER
+        # Schema now defines fhrsid as STRING
         bq_schema = [
-            bigquery.SchemaField('fhrsid', 'INTEGER'), # Changed to INTEGER
+            bigquery.SchemaField('fhrsid', 'STRING'), # Changed to STRING
             bigquery.SchemaField('another_col', 'STRING')
         ]
 
@@ -661,12 +668,12 @@ class TestAppendToBigQuery(unittest.TestCase): # Changed to use unittest.TestCas
         args, kwargs = mock_bq_client_instance.load_table_from_dataframe.call_args
         loaded_df = args[0]
 
-        # Assert that 'fhrsid' column in the loaded_df is of integer type
-        self.assertTrue(pd.api.types.is_integer_dtype(loaded_df['fhrsid']),
-                        f"fhrsid column should be integer type, but was {loaded_df['fhrsid'].dtype}")
+        # Assert that 'fhrsid' column in the loaded_df is of string type
+        self.assertTrue(pd.api.types.is_string_dtype(loaded_df['fhrsid']),
+                        f"fhrsid column should be string type, but was {loaded_df['fhrsid'].dtype}")
 
         # Also check the values
-        self.assertEqual(loaded_df['fhrsid'].tolist(), [123, 456, 789])
+        self.assertEqual(loaded_df['fhrsid'].tolist(), ["123", "456", "789"])
 
 
 # If __name__ == '__main__':

--- a/test_data_processing.py
+++ b/test_data_processing.py
@@ -47,8 +47,8 @@ class TestLoadMasterData(unittest.TestCase):
     def test_load_master_data_success_and_manual_review_init(self, mock_st):
         # Mock for the load_bq_func argument
         mock_bq_loader = MagicMock(return_value=[
-            {'FHRSID': 1, 'name': 'Restaurant A'},
-            {'FHRSID': 2, 'name': 'Restaurant B', 'manual_review': 'already_reviewed'}
+            {'FHRSID': "1", 'name': 'Restaurant A'}, # FHRSID is string
+            {'FHRSID': "2", 'name': 'Restaurant B', 'manual_review': 'already_reviewed'} # FHRSID is string
         ])
 
         project_id = "test_p"
@@ -96,8 +96,8 @@ class TestLoadMasterData(unittest.TestCase):
 class TestProcessAndUpdateMasterData(unittest.TestCase):
     @patch('data_processing.st') # Mock streamlit
     def test_no_new_restaurants(self, mock_st):
-        master_data = [{'FHRSID': 1, 'name': 'A'}]
-        api_data = {'FHRSEstablishment': {'EstablishmentCollection': {'EstablishmentDetail': [{'FHRSID': 1, 'name': 'A'}]}}}
+        master_data = [{'FHRSID': "1", 'name': 'A'}] # FHRSID is string
+        api_data = {'FHRSEstablishment': {'EstablishmentCollection': {'EstablishmentDetail': [{'FHRSID': "1", 'name': 'A'}]}}} # FHRSID is string
         new_restaurants = process_and_update_master_data(master_data, api_data)
         self.assertEqual(len(new_restaurants), 0)
         mock_st.info.assert_called_once_with("Processed API response. No new restaurant records identified.")
@@ -108,11 +108,11 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
         # Setup mock for datetime.now().strftime()
         mock_datetime.now.return_value.strftime.return_value = "2023-10-26"
 
-        master_data = [{'FHRSID': 1, 'name': 'A'}]
+        master_data = [{'FHRSID': "1", 'name': 'A'}] # FHRSID is string
         # Define API data with one existing and two new restaurants
-        api_restaurant_1_existing = {'FHRSID': 1, 'name': 'A_updated'}
-        api_restaurant_2_new = {'FHRSID': 2, 'name': 'B', 'RatingValue': '5'}
-        api_restaurant_3_new = {'FHRSID': 3, 'name': 'C'}
+        api_restaurant_1_existing = {'FHRSID': "1", 'name': 'A_updated'} # FHRSID is string
+        api_restaurant_2_new = {'FHRSID': "2", 'name': 'B', 'RatingValue': '5'} # FHRSID is string
+        api_restaurant_3_new = {'FHRSID': "3", 'name': 'C'} # FHRSID is string
 
         api_data = {'FHRSEstablishment': {'EstablishmentCollection': {'EstablishmentDetail': [
             api_restaurant_1_existing,
@@ -126,17 +126,17 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
 
         # Check if the new restaurants are the correct ones (order might not be guaranteed)
         fhrsid_in_new = [r['FHRSID'] for r in new_restaurants]
-        self.assertIn(2, fhrsid_in_new)
-        self.assertIn(3, fhrsid_in_new)
+        self.assertIn("2", fhrsid_in_new) # Expect string FHRSID
+        self.assertIn("3", fhrsid_in_new) # Expect string FHRSID
 
         # Check properties of the new restaurants
         for r_new in new_restaurants:
             self.assertEqual(r_new['first_seen'], "2023-10-26")
             self.assertEqual(r_new['manual_review'], "not reviewed")
-            if r_new['FHRSID'] == 2: # api_restaurant_2_new
+            if r_new['FHRSID'] == "2": # api_restaurant_2_new, compare with string
                 self.assertEqual(r_new['name'], 'B')
                 self.assertEqual(r_new['RatingValue'], '5') # Ensure other fields preserved
-            elif r_new['FHRSID'] == 3: # api_restaurant_3_new
+            elif r_new['FHRSID'] == "3": # api_restaurant_3_new, compare with string
                  self.assertEqual(r_new['name'], 'C')
 
         mock_st.success.assert_called_once_with("Processed API response. Identified 2 new restaurant records to be added.")
@@ -144,7 +144,7 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
     @patch('data_processing.st')
     def test_empty_master_data_all_api_items_are_new(self, mock_st):
         master_data = []
-        api_restaurant = {'FHRSID': 1, 'name': 'A'}
+        api_restaurant = {'FHRSID': "1", 'name': 'A'} # FHRSID is string
         api_data = {'FHRSEstablishment': {'EstablishmentCollection': {'EstablishmentDetail': [api_restaurant]}}}
 
         with patch('data_processing.datetime') as mock_dt: # Mock datetime for first_seen
@@ -152,13 +152,13 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
             new_restaurants = process_and_update_master_data(master_data, api_data)
 
         self.assertEqual(len(new_restaurants), 1)
-        self.assertEqual(new_restaurants[0]['FHRSID'], 1)
+        self.assertEqual(new_restaurants[0]['FHRSID'], "1") # Expect string FHRSID
         self.assertEqual(new_restaurants[0]['first_seen'], "mock_date")
         self.assertEqual(new_restaurants[0]['manual_review'], "not reviewed")
 
     @patch('data_processing.st')
     def test_empty_api_data_detail(self, mock_st):
-        master_data = [{'FHRSID': 1, 'name': 'A'}]
+        master_data = [{'FHRSID': "1", 'name': 'A'}] # FHRSID is string
         api_data = {'FHRSEstablishment': {'EstablishmentCollection': {'EstablishmentDetail': []}}}
         new_restaurants = process_and_update_master_data(master_data, api_data)
         self.assertEqual(len(new_restaurants), 0)
@@ -167,7 +167,7 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
 
     @patch('data_processing.st')
     def test_api_data_establishment_detail_is_none(self, mock_st):
-        master_data = [{'FHRSID': 1, 'name': 'A'}]
+        master_data = [{'FHRSID': "1", 'name': 'A'}] # FHRSID is string
         api_data = {'FHRSEstablishment': {'EstablishmentCollection': {'EstablishmentDetail': None}}}
         new_restaurants = process_and_update_master_data(master_data, api_data)
         self.assertEqual(len(new_restaurants), 0)
@@ -175,7 +175,7 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
 
     @patch('data_processing.st')
     def test_api_data_missing_establishment_collection(self, mock_st):
-        master_data = [{'FHRSID': 1, 'name': 'A'}]
+        master_data = [{'FHRSID': "1", 'name': 'A'}] # FHRSID is string
         api_data = {'FHRSEstablishment': {}} # EstablishmentCollection is missing
         new_restaurants = process_and_update_master_data(master_data, api_data)
         self.assertEqual(len(new_restaurants), 0)
@@ -196,7 +196,7 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
 
     @patch('data_processing.st')
     def test_api_data_missing_fhrestablishment_key(self, mock_st):
-        master_data = [{'FHRSID': 1, 'name': 'A'}]
+        master_data = [{'FHRSID': "1", 'name': 'A'}] # FHRSID is string
         api_data = {} # FHRSEstablishment key is missing
         new_restaurants = process_and_update_master_data(master_data, api_data)
         self.assertEqual(len(new_restaurants), 0)
@@ -205,20 +205,17 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
 
     @patch('data_processing.datetime')
     @patch('data_processing.st')
-    def test_fhrsid_is_integer_after_processing(self, mock_st, mock_datetime):
+    def test_fhrsid_is_string_after_processing(self, mock_st, mock_datetime): # Renamed test
         """
-        Test that FHRSID remains an integer if it's an integer in the API data and when processed.
+        Test that FHRSID is a string after processing, regardless of original type from API.
         """
         # Setup mock for datetime.now().strftime()
         mock_datetime.now.return_value.strftime.return_value = "2023-10-27"
 
         master_data = [] # No existing master data
 
-        # API data with one establishment having an integer FHRSID
-        # The FHRSID from API is expected to be an integer or string that can be converted to int.
-        # data_processing.py now tries to convert to int.
+        # API data with FHRSID as integer and string
         api_establishment_int_fhrsid = {'FHRSID': 123, 'name': 'Testaurant'}
-        # Test with string FHRSID from API that should be converted
         api_establishment_str_fhrsid = {'FHRSID': "456", 'name': 'Another Testaurant'}
 
         api_data = {
@@ -235,18 +232,18 @@ class TestProcessAndUpdateMasterData(unittest.TestCase):
         self.assertEqual(len(new_restaurants), 2, "Should find two new restaurants")
         mock_st.success.assert_called_once_with("Processed API response. Identified 2 new restaurant records to be added.")
 
-        # Check first restaurant (originally int FHRSID)
+        # Check first restaurant (originally int FHRSID from API)
         added_restaurant_1 = next(r for r in new_restaurants if r['name'] == 'Testaurant')
-        self.assertIsInstance(added_restaurant_1['FHRSID'], int, "FHRSID should be an integer for original int FHRSID")
-        self.assertEqual(added_restaurant_1['FHRSID'], 123, "FHRSID should be the integer 123")
+        self.assertIsInstance(added_restaurant_1['FHRSID'], str, "FHRSID should be a string")
+        self.assertEqual(added_restaurant_1['FHRSID'], "123", "FHRSID should be the string '123'")
         self.assertEqual(added_restaurant_1['name'], 'Testaurant')
         self.assertEqual(added_restaurant_1['first_seen'], "2023-10-27")
         self.assertEqual(added_restaurant_1['manual_review'], "not reviewed")
 
-        # Check second restaurant (originally string FHRSID, should be converted)
+        # Check second restaurant (originally string FHRSID from API)
         added_restaurant_2 = next(r for r in new_restaurants if r['name'] == 'Another Testaurant')
-        self.assertIsInstance(added_restaurant_2['FHRSID'], int, "FHRSID should be an integer for original string FHRSID")
-        self.assertEqual(added_restaurant_2['FHRSID'], 456, "FHRSID should be the integer 456")
+        self.assertIsInstance(added_restaurant_2['FHRSID'], str, "FHRSID should be a string")
+        self.assertEqual(added_restaurant_2['FHRSID'], "456", "FHRSID should be the string '456'")
         self.assertEqual(added_restaurant_2['name'], 'Another Testaurant')
         self.assertEqual(added_restaurant_2['first_seen'], "2023-10-27")
         self.assertEqual(added_restaurant_2['manual_review'], "not reviewed")


### PR DESCRIPTION
The fhrsid field was previously being inferred as INTEGER in some parts of the pipeline, leading to schema mismatch errors when writing to BigQuery.

This commit addresses the issue by:
- Modifying `bq_utils.py`:
    - Updated BigQuery schema definitions to specify fhrsid as STRING.
    - Removed logic that converted fhrsid to INTEGER before writing.
    - Ensured fhrsid is explicitly cast to STRING before BigQuery operations.
    - Updated functions reading or updating data based on fhrsid to expect STRING values.
- Modifying `data_processing.py`:
    - Ensured FHRSID from API responses is treated as STRING.
    - Removed logic that converted FHRSID to INTEGER during processing.
- Updating unit tests:
    - Adjusted test data and assertions in `test_bq_utils.py` and `test_data_processing.py` to reflect that fhrsid/FHRSID is now a STRING.
    - All tests pass with these changes.