### PR TITLE
Refactor: Remove GCS upload for master restaurant data

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -236,7 +236,7 @@ def _fetch_data_for_all_coordinates(valid_coords: List[tuple[float, float]], max
             all_api_establishments.extend(establishments_list)
     return all_api_establishments
 
-def _handle_gcs_uploads(api_data: Dict[str, Any], master_restaurant_data: List[Dict[str, Any]], gcs_destination_uri_str: str, gcs_master_output_uri_str: str):
+def _handle_gcs_uploads(api_data: Dict[str, Any], master_restaurant_data: List[Dict[str, Any]], gcs_destination_uri_str: str):
     """
     Handles uploading API response and master restaurant data to GCS.
     """
@@ -251,11 +251,6 @@ def _handle_gcs_uploads(api_data: Dict[str, Any], master_restaurant_data: List[D
             st.success(f"Successfully uploaded combined raw API response to {full_gcs_path_api_response}")
         # upload_to_gcs internally handles and logs errors if upload fails
     
-    if gcs_master_output_uri_str:
-        if upload_to_gcs(data=master_restaurant_data, destination_uri=gcs_master_output_uri_str):
-            st.success(f"Successfully uploaded master restaurant data to {gcs_master_output_uri_str}")
-        # upload_to_gcs internally handles and logs errors if upload fails
-
 def _write_data_to_bigquery(master_restaurant_data: List[Dict[str, Any]], bq_full_path_str: str):
     """
     Prepares and writes master restaurant data to BigQuery.
@@ -345,7 +340,6 @@ def handle_fetch_data_action(
     max_results: int,
     gcs_destination_uri_str: str,
     master_list_uri_str: str,
-    gcs_master_output_uri_str: str,
     bq_full_path_str: str
 ) -> List[Dict[str, Any]]:
     """
@@ -411,7 +405,7 @@ def handle_fetch_data_action(
     master_restaurant_data, _ = process_and_update_master_data(master_restaurant_data, combined_api_data)
 
     # 5. Handle GCS Uploads
-    _handle_gcs_uploads(combined_api_data, master_restaurant_data, gcs_destination_uri_str, gcs_master_output_uri_str)
+    _handle_gcs_uploads(combined_api_data, master_restaurant_data, gcs_destination_uri_str)
 
     # 6. Display data
     display_data(master_restaurant_data)
@@ -450,7 +444,6 @@ def main_ui():
         max_results_input_ui = st.number_input("Enter Max Results for API Call", min_value=1, max_value=5000, value=200)
         gcs_destination_uri_ui = st.text_input("Enter GCS destination folder for the scan (e.g., gs://bucket-name/scans-folder/)")
         master_list_uri_ui = st.text_input("Master Restaurant BigQuery Table (project.dataset.table)")
-        gcs_master_dictionary_output_uri_ui = st.text_input("Enter GCS URI for Master Restaurant Data Output (e.g., gs://bucket-name/path/filename.json)")
         bq_full_path_ui = st.text_input("Enter BigQuery Table Path to write updated data (project.dataset.table)")
 
         if st.button("Fetch Data"):
@@ -459,7 +452,6 @@ def main_ui():
                 max_results=max_results_input_ui,
                 gcs_destination_uri_str=gcs_destination_uri_ui,
                 master_list_uri_str=master_list_uri_ui,
-                gcs_master_output_uri_str=gcs_master_dictionary_output_uri_ui,
                 bq_full_path_str=bq_full_path_ui
             )
     elif app_mode == "FHRSID Lookup":


### PR DESCRIPTION
This change removes the functionality that writes the master restaurant data file back to Google Cloud Storage.

The following modifications were made:
- The `_handle_gcs_uploads` function in `st_app.py` was updated to no longer upload the master data. It still uploads the raw API response if a GCS destination URI is provided.
- The `gcs_master_output_uri_str` parameter was removed from `_handle_gcs_uploads` and `handle_fetch_data_action` in `st_app.py`.
- The corresponding UI input field ("Enter GCS URI for Master Restaurant Data Output") was removed from the Streamlit application.
- A new unit test was added to `test_st_app.py` to verify that master data is not uploaded by `_handle_gcs_uploads`.
- Existing unit tests in `test_st_app.py` were updated to reflect the changes in function signatures and behavior, ensuring all tests pass.