### PR TITLE
Fix: Align FHRSID to STRING schema for fsa_master append

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -334,7 +334,7 @@ def _append_new_data_to_bigquery(new_restaurants: List[Dict[str, Any]], project_
     # Define comprehensive schema for append operation
     # Ensures all expected columns from new_restaurants are included and correctly typed.
     bq_schema_for_append = [
-        bigquery.SchemaField(sanitize_column_name('FHRSID'), 'INTEGER'), # FHRSID is typically integer
+        bigquery.SchemaField(sanitize_column_name('FHRSID'), 'STRING'), # FHRSID is typically integer
         bigquery.SchemaField(sanitize_column_name('LocalAuthorityBusinessID'), 'STRING'),
         bigquery.SchemaField(sanitize_column_name('BusinessName'), 'STRING'),
         bigquery.SchemaField(sanitize_column_name('BusinessType'), 'STRING'),
@@ -402,10 +402,11 @@ def _append_new_data_to_bigquery(new_restaurants: List[Dict[str, Any]], project_
             # It's possible scores are not present for all records, so this might not be a warning if optional
             print(f"Info: Score column '{s_col_name}' not found in new restaurants DataFrame. Will be skipped if not in schema or be Null.")
 
-    # Ensure FHRSID is integer
+    # Ensure FHRSID is string
     s_fhrsid = sanitize_column_name('FHRSID')
     if s_fhrsid in df_new_restaurants.columns:
-        df_new_restaurants[s_fhrsid] = pd.to_numeric(df_new_restaurants[s_fhrsid], errors='coerce').astype('Int64')
+        # Convert all values in the column to string, including None or NA
+        df_new_restaurants[s_fhrsid] = df_new_restaurants[s_fhrsid].astype(str)
 
     s_business_type_id = sanitize_column_name('BusinessTypeID')
     if s_business_type_id in df_new_restaurants.columns:


### PR DESCRIPTION
The application was encountering a schema mismatch error when appending new records to the filipegracio-ai-learning.filipegracio_fsa_restaurants.fsa_master table. The error indicated that the 'fhrsid' field was being provided as INTEGER while the table expected STRING.

This was caused by st_app.py defining the schema for 'FHRSID' as INTEGER and converting 'FHRSID' data to numeric types before calling the append_to_bigquery utility. However, the underlying fsa_master table has 'FHRSID' as a STRING.

This commit fixes the issue by:
1. Modifying the `_append_new_data_to_bigquery` function in `st_app.py` to define the `bigquery.SchemaField` for `FHRSID` as `STRING`.
2. Updating the data handling for the `FHRSID` column in `st_app.py` to ensure it is explicitly treated as a string (`astype(str)`) before being passed to the append function. This aligns with data_processing.py, which already provides FHRSID as a string.

The `bq_utils.append_to_bigquery` function was already capable of handling string FHRSIDs correctly when provided with the appropriate schema, so no changes were needed there.