### PR TITLE
Fix: Correct FHRSID key usage for BigQuery deduplication

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -91,12 +91,12 @@ def process_and_update_master_data(master_data: List[Dict[str, Any]], api_data: 
 
     existing_fhrsid_set = set()
     for est in master_data:
-        if isinstance(est, dict) and 'FHRSID' in est and est['FHRSID'] is not None:
+        if isinstance(est, dict) and 'fhrsid' in est and est['fhrsid'] is not None:
             try:
-                canonical_fhrsid = str(int(est['FHRSID']))
+                canonical_fhrsid = str(int(est['fhrsid']))
             except ValueError:
-                canonical_fhrsid = str(est['FHRSID'])
-                st.warning(f"FHRSID '{est['FHRSID']}' from master_data could not be converted to int. Using original string value for comparison.")
+                canonical_fhrsid = str(est['fhrsid'])
+                st.warning(f"FHRSID '{est['fhrsid']}' from master_data could not be converted to int. Using original string value for comparison.")
             existing_fhrsid_set.add(canonical_fhrsid)
 
     today_date = datetime.now().strftime("%Y-%m-%d")


### PR DESCRIPTION
The previous implementation incorrectly used 'FHRSID' (uppercase) when attempting to read FHRSID values from master data loaded from BigQuery. The actual column name in BigQuery (and thus in the loaded dictionaries) is 'fhrsid' (lowercase).

This mismatch caused the `existing_fhrsid_set` in
`process_and_update_master_data` to always be empty. Consequently, all records from API calls, even if already present in BigQuery, were treated as new and appended, leading to duplicate entries in the BigQuery table.

This commit changes `data_processing.py` to use the correct lowercase key 'fhrsid' when accessing and processing FHRSIDs from the master_data list.

A new unit test, `test_deduplication_with_corrected_fhrsid_key`, has been added to `test_data_processing.py` to specifically verify this fix. The test ensures that deduplication works correctly with the lowercase 'fhrsid' key in master data for both numeric and non-numeric FHRSIDs, and that only genuinely new records are processed for addition.