### PR TITLE
Refactor: Remove full dataset display from Streamlit app

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -557,7 +557,6 @@ def handle_fetch_data_action(
     # it would need to either re-load from BQ or combine master_restaurant_data + new_restaurants (if df versions are compatible).
     # For now, sticking to displaying initial load.
     st.info("Displaying master data loaded from BigQuery (before current API fetch append). Refresh page or re-fetch to see appended data reflected in subsequent loads.")
-    display_data(master_restaurant_data)
 
     # If new_restaurants were found, also display them for clarity in this run
     if new_restaurants:


### PR DESCRIPTION
This change removes the display of the full dataset in the Streamlit application. The section displaying newly identified restaurants remains unchanged.

The `display_data(master_restaurant_data)` call within the `handle_fetch_data_action` function in `st_app.py` has been removed to achieve this.