### PR TITLE
fix: Correct st.session_state mocking in tests

### DIFF
--- a/test_st_app.py
+++ b/test_st_app.py
@@ -15,7 +15,12 @@ from data_processing import process_and_update_master_data
 class TestMainUI(unittest.TestCase):
     def test_main_ui_radio_options(self, mock_st_global):
         # Mock session state if it's accessed by main_ui before radio
-        mock_st_global.session_state = {'recent_restaurants_df': None}
+        # Change to MagicMock to allow attribute assignment like st.session_state.displaying_genai_temp
+        mock_st_global.session_state = MagicMock()
+        mock_st_global.session_state.recent_restaurants_df = None
+        # Other session state variables like 'current_project_id', 'current_dataset_id',
+        # and 'displaying_genai_temp' will be initialized by main_ui if not present,
+        # which MagicMock handles correctly for 'in' checks and attribute setting.
 
         main_ui()
 


### PR DESCRIPTION
The test `TestMainUI.test_main_ui_radio_options` in `test_st_app.py` was failing with an `AttributeError`. This was due to `st.session_state` being mocked as a plain dictionary, which does not support attribute-style assignment (e.g., `st.session_state.my_var = value`) as used in your application code (`st_app.py`).

This commit changes the mocking of `st.session_state` in the affected test to use `unittest.mock.MagicMock`. This allows attribute access and assignment, aligning the mock's behavior with Streamlit's actual session state object and resolving the test failure.

The specific change involves:
- Modifying `mock_st_global.session_state` in `TestMainUI.test_main_ui_radio_options` to be a `MagicMock()`.
- Setting `mock_st_global.session_state.recent_restaurants_df = None` on this mock to preserve the original test's specific setup.

All tests now pass with this correction.