### PR TITLE
Fix: Escape backslashes in BigQuery string literals

### DIFF
--- a/bq_utils.py
+++ b/bq_utils.py
@@ -326,7 +326,7 @@ def update_rows_in_bigquery(project_id: str, dataset_id: str, table_id: str, fhr
     for column, value in update_data.items():
         if isinstance(value, str):
             # Escape single quotes within the string value itself
-            sanitized_value = value.replace("'", "''")
+            sanitized_value = value.replace('\\', '\\\\').replace("'", "''")
             set_clauses.append(f"`{column}` = '{sanitized_value}'")
         elif isinstance(value, bool):
             set_clauses.append(f"`{column}` = {str(value).upper()}")
@@ -337,7 +337,7 @@ def update_rows_in_bigquery(project_id: str, dataset_id: str, table_id: str, fhr
         else:
             # Fallback for other types, assuming string representation is acceptable
             # or specific handling might be needed for other types (e.g., DATE, TIMESTAMP)
-            sanitized_value = str(value).replace("'", "''")
+            sanitized_value = str(value).replace('\\', '\\\\').replace("'", "''")
             print(f"Warning: Column '{column}' has an unhandled type {type(value)}. Converting to string: '{sanitized_value}'")
             set_clauses.append(f"`{column}` = '{sanitized_value}'")
 


### PR DESCRIPTION
The `update_rows_in_bigquery` function was encountering a syntax error: "Syntax error: concatenated string literals must be separated by whitespace or comments".

This error can occur if string literals are not properly escaped, leading BigQuery to misinterpret the query structure, potentially seeing two string literals adjacent without a proper separator.

This commit enhances the string sanitization by:
1. Replacing backslashes (`\`) with double backslashes (`\\`).
2. Then, replacing single quotes (`'`) with double single quotes (`''`).

This ensures that backslashes are treated as literal characters and do not interfere with the escaping of single quotes, providing more robust handling of arbitrary string data for BigQuery UPDATE statements.