### PR TITLE
Refactor: Update string sanitization for BigQuery updates

### DIFF
--- a/bq_utils.py
+++ b/bq_utils.py
@@ -326,7 +326,7 @@ def update_rows_in_bigquery(project_id: str, dataset_id: str, table_id: str, fhr
     for column, value in update_data.items():
         if isinstance(value, str):
             # Escape single quotes within the string value itself
-            sanitized_value = value.replace("'", "''")
+            sanitized_value = value.replace("'", "").replace('\\', '\\\\')
             set_clauses.append(f"`{column}` = '{sanitized_value}'")
         elif isinstance(value, bool):
             set_clauses.append(f"`{column}` = {str(value).upper()}")
@@ -337,7 +337,7 @@ def update_rows_in_bigquery(project_id: str, dataset_id: str, table_id: str, fhr
         else:
             # Fallback for other types, assuming string representation is acceptable
             # or specific handling might be needed for other types (e.g., DATE, TIMESTAMP)
-            sanitized_value = str(value).replace("'", "''")
+            sanitized_value = str(value).replace("'", "").replace('\\', '\\\\')
             print(f"Warning: Column '{column}' has an unhandled type {type(value)}. Converting to string: '{sanitized_value}'")
             set_clauses.append(f"`{column}` = '{sanitized_value}'")
 


### PR DESCRIPTION
This commit changes the string sanitization logic in the `update_rows_in_bigquery` function based on new requirements:

1. All single apostrophes (') are removed from string values. (e.g., "O'Malley's" becomes "OMalleys").
2. After apostrophe removal, any backslashes (\) are escaped by doubling them (e.g., "C:\data" becomes "C:\\data").

This approach aims to prevent syntax errors in BigQuery by simplifying string content, specifically by removing apostrophes, and ensuring backslashes are treated as literal characters. This replaces previous methods of escaping apostrophes.