### PR TITLE
Fix: Correct single quote escaping in BigQuery UPDATE

### DIFF
--- a/bq_utils.py
+++ b/bq_utils.py
@@ -326,7 +326,7 @@ def update_rows_in_bigquery(project_id: str, dataset_id: str, table_id: str, fhr
     for column, value in update_data.items():
         if isinstance(value, str):
             # Escape single quotes within the string value itself
-            sanitized_value = value.replace("'", "").replace('\\', '\\\\')
+            sanitized_value = value.replace("'", "''").replace('\\', '\\\\')
             set_clauses.append(f"`{column}` = '{sanitized_value}'")
         elif isinstance(value, bool):
             set_clauses.append(f"`{column}` = {str(value).upper()}")
@@ -337,7 +337,7 @@ def update_rows_in_bigquery(project_id: str, dataset_id: str, table_id: str, fhr
         else:
             # Fallback for other types, assuming string representation is acceptable
             # or specific handling might be needed for other types (e.g., DATE, TIMESTAMP)
-            sanitized_value = str(value).replace("'", "").replace('\\', '\\\\')
+            sanitized_value = str(value).replace("'", "''").replace('\\', '\\\\')
             print(f"Warning: Column '{column}' has an unhandled type {type(value)}. Converting to string: '{sanitized_value}'")
             set_clauses.append(f"`{column}` = '{sanitized_value}'")
 


### PR DESCRIPTION
The function `update_rows_in_bigquery` in `bq_utils.py` was previously removing single quotes from string values (value.replace("'", "")) before constructing an SQL UPDATE statement. This could lead to data corruption and, in certain scenarios, potentially contribute to "Unclosed string literal" errors if the removal was insufficient for complex strings.

This commit changes the sanitization to correctly escape single quotes by doubling them (value.replace("'", "''")). This is the standard SQL method for escaping single quotes within string literals, ensuring data integrity and preventing parsing errors for columns like 'gemini_insights' that contain free-form text.