### PR TITLE
Refactor 'Update Fields' section to use MERGE query

### DIFF
--- a/bq_utils.py
+++ b/bq_utils.py
@@ -8,12 +8,16 @@ ORIGINAL_COLUMNS_TO_KEEP = [
     'first_seen', 'manual_review', 'gemini_insights'
 ]
 
-from google.cloud import bigquery
+from google.cloud import bigquery, exceptions as google_cloud_exceptions # Added google_cloud_exceptions
 from google.cloud.bigquery.client import Client # Explicit import for type hinting if needed elsewhere
 from typing import List, Dict, Any # Removed Optional, Added Dict, Any
 import re
 import pandas_gbq # Added import
 from google.auth.exceptions import DefaultCredentialsError # Added import
+import logging # Added import
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 # Custom Exceptions
 class BigQueryExecutionError(Exception):
@@ -376,4 +380,45 @@ def update_rows_in_bigquery(project_id: str, dataset_id: str, table_id: str, fhr
     except Exception as e:
         print(f"An error occurred during BigQuery UPDATE: {e}")
         # st.error(f"An error occurred during BigQuery UPDATE: {e}")
+        return False
+
+def execute_merge_query(merge_query: str, project_id: str) -> bool:
+    """
+    Executes a MERGE SQL query in BigQuery.
+
+    Args:
+        merge_query: The MERGE SQL query string.
+        project_id: The Google Cloud project ID where the query will be run.
+
+    Returns:
+        True if the query executes successfully, False otherwise.
+    """
+    logging.info(f"Attempting to execute MERGE query in project '{project_id}':\n{merge_query}")
+    try:
+        client = bigquery.Client(project=project_id)
+        query_job = client.query(merge_query)
+        query_job.result()  # Wait for the job to complete
+
+        if query_job.errors:
+            logging.error(f"MERGE query failed with errors: {query_job.errors}")
+            # Optionally, include errors in Streamlit if this function is called directly from UI context
+            # st.error(f"BigQuery MERGE query failed: {query_job.errors}")
+            return False
+
+        logging.info("MERGE query executed successfully.")
+        # num_affected_rows might be available depending on the query and BQ API version
+        # For example: if query_job.num_dml_affected_rows is not None:
+        # logging.info(f"Number of rows affected by MERGE query: {query_job.num_dml_affected_rows}")
+        return True
+    except DefaultCredentialsError as e:
+        logging.error(f"BigQuery authentication error during MERGE query execution: {e}. Ensure ADC is configured.")
+        # st.error(f"BigQuery authentication error: {e}")
+        return False
+    except google_cloud_exceptions.GoogleCloudError as e: # More specific Google Cloud exceptions
+        logging.error(f"A Google Cloud error occurred during MERGE query execution: {e}")
+        # st.error(f"A Google Cloud error occurred: {e}")
+        return False
+    except Exception as e:
+        logging.error(f"An unexpected error occurred during MERGE query execution: {e}")
+        # st.error(f"An unexpected error occurred: {e}")
         return False

--- a/st_app.py
+++ b/st_app.py
@@ -17,6 +17,7 @@ from bq_utils import (
     write_to_bigquery,
     load_all_data_from_bq, # Added import
     append_to_bigquery, # Added for new flow
+    execute_merge_query, # Added for MERGE operation
     BigQueryExecutionError,  # Added import
     DataFrameConversionError, # Added import
     get_recent_restaurants
@@ -708,27 +709,122 @@ def main_ui():
                         st.error(f"An error occurred during Gemini analysis or subsequent table update: {e}")
 
     elif app_mode == "Update Fields":
-        st.subheader("Update Table Fields from CSV")
+        st.subheader("Update Table Fields using MERGE")
 
-        bq_master_table_path_update = st.text_input(
-            "Enter BigQuery master table path to update (project.dataset.table)",
-            key="bq_master_table_update"
+        master_table_path_input = st.text_input(
+            "Enter BigQuery master table path (project.dataset.table)",
+            key="merge_master_table_path"
+        )
+        update_table_path_input = st.text_input(
+            "Enter BigQuery update table path (project.dataset.table)",
+            key="merge_update_table_path"
+        )
+        matching_id_input = st.text_input(
+            "Enter the matching ID column name (e.g., fhrsid)",
+            key="merge_matching_id"
+        )
+        field_to_update_input = st.text_input(
+            "Enter the field to update from the update table",
+            key="merge_field_to_update"
         )
 
-        uploaded_csv_file = st.file_uploader(
-            "Upload CSV file with 'fhrsid' and columns to update",
-            type=["csv"],
-            key="csv_updater"
-        )
-
-        if st.button("Update Table from CSV", key="update_csv_button"):
-            if not bq_master_table_path_update:
-                st.error("Please enter the BigQuery master table path.")
-            elif uploaded_csv_file is None:
-                st.warning("Please upload a CSV file.")
+        if st.button("Update Fields from Table", key="merge_update_button"):
+            if not all([master_table_path_input, update_table_path_input, matching_id_input, field_to_update_input]):
+                st.error("Please fill in all the fields for the MERGE operation.")
             else:
-                handle_update_fields_action(bq_master_table_path_update, uploaded_csv_file)
+                handle_merge_update_action(
+                    master_table_path_input,
+                    update_table_path_input,
+                    matching_id_input,
+                    field_to_update_input
+                )
 
 
 if __name__ == "__main__":
     main_ui()
+def handle_merge_update_action(master_table_path: str, update_table_path: str, matching_id: str, field_to_update: str):
+    """
+    Constructs and executes a MERGE SQL query to update a field in the master table
+    from an update table. After successful execution, it fetches and displays the master table.
+    """
+    st.info(f"Initiating MERGE operation to update '{field_to_update}' in '{master_table_path}' using '{update_table_path}' on matching '{matching_id}'.")
+
+    try:
+        master_parts = master_table_path.split('.')
+        update_parts = update_table_path.split('.')
+        if len(master_parts) != 3 or not all(master_parts):
+            st.error(f"Invalid BigQuery Master Table Path: '{master_table_path}'. Expected 'project.dataset.table'.")
+            return
+        if len(update_parts) != 3 or not all(update_parts):
+            st.error(f"Invalid BigQuery Update Table Path: '{update_table_path}'. Expected 'project.dataset.table'.")
+            return
+
+        master_project_id, master_dataset_id, master_table_id = master_parts
+        # Assuming update table is in the same project, which is common for MERGE.
+        # If not, the query needs to qualify the update table path fully.
+        # For now, we'll assume the paths provided are fully qualified if cross-project.
+
+        # Sanitize column names for safety, though BQ is generally okay with original names in queries if not keywords.
+        # However, matching_id and field_to_update are used directly in SQL.
+        # It's crucial these don't contain SQL injection if they were from less trusted sources.
+        # For this app, they come from text inputs, so less risk, but good to be aware.
+        # No actual sanitization applied here to keep it simple, assuming valid column names.
+
+        merge_query = f"""
+        MERGE `{master_table_path}` T
+        USING `{update_table_path}` S
+        ON T.{matching_id} = S.{matching_id}
+        WHEN MATCHED THEN
+          UPDATE SET T.{field_to_update} = S.{field_to_update}
+        """
+
+        st.info("Constructed MERGE query. Executing...")
+        st.code(merge_query, language="sql")
+
+        # Placeholder for the actual BQ execution function
+        # This function needs to be created in bq_utils.py
+        # It should take the query and project_id (for client initialization)
+        # from bq_utils import execute_merge_query # This import would be at the top of the file
+
+        # For now, let's assume bq_utils.execute_merge_query exists and works
+        # We'll need to import it at the top of st_app.py
+        # from bq_utils import execute_merge_query (ensure this import is added)
+
+        # The project_id for execute_merge_query should ideally be the one where the query runs,
+        # which is typically the project of the master table.
+        # query_project_id = master_project_id
+
+        # Simulate execution for now
+        # success = bq_utils.execute_merge_query(merge_query, project_id=query_project_id)
+
+        # --- SIMULATED EXECUTION ---
+        st.warning("Simulating MERGE query execution. `bq_utils.execute_merge_query` needs to be implemented.")
+        # To make this runnable without the actual bq_utils.execute_merge_query:
+        # The project_id for execute_merge_query should ideally be the one where the query runs,
+        # which is typically the project of the master table.
+        query_project_id = master_project_id
+
+        success = execute_merge_query(merge_query, project_id=query_project_id)
+
+        if success:
+            st.success("MERGE operation completed successfully.")
+            st.info(f"Loading and displaying updated master table: {master_table_path}")
+
+            updated_master_data = load_all_data_from_bq(
+                project_id=master_project_id,
+                dataset_id=master_dataset_id,
+                table_id=master_table_id
+            )
+            if updated_master_data:
+                display_data(updated_master_data)
+            else:
+                st.warning(f"Could not load data from {master_table_path} after update, or table is empty.")
+        else:
+            st.error("MERGE operation failed. Check logs for details.")
+
+    except ValueError as ve: # Catches split issues if paths are malformed
+        st.error(f"Error parsing BigQuery table paths: {ve}")
+    except ImportError:
+        st.error("A required BigQuery utility function (e.g., execute_merge_query or load_all_data_from_bq) is not available. Please ensure bq_utils.py is correct and all imports are set up.")
+    except Exception as e:
+        st.error(f"An unexpected error occurred during the MERGE operation: {e}")

--- a/test_st_app.py
+++ b/test_st_app.py
@@ -260,5 +260,80 @@ class TestRecentRestaurantAnalysisGeminiUpdate(unittest.TestCase):
         mock_st_global.warning.assert_any_call("Failed to update insights for FHRSID 890. Check logs.")
         mock_st_global.error.assert_any_call("Update summary: Successfully updated 0 rows. Failed to update 2 rows.")
 
+
+class TestHandleMergeUpdateAction(unittest.TestCase):
+    @patch('st_app.display_data')
+    @patch('st_app.bq_utils.load_all_data_from_bq')
+    @patch('st_app.bq_utils.execute_merge_query')
+    @patch('st_app.st') # Mock streamlit module
+    def test_handle_merge_update_action_success(self, mock_st, mock_execute_merge_query, mock_load_all_data, mock_display_data):
+        mock_execute_merge_query.return_value = True
+        sample_data = [{'col1': 'data1', 'col2': 'value1'}]
+        mock_load_all_data.return_value = sample_data
+
+        master_path = "proj.dataset.master_table"
+        update_path = "proj.dataset.update_table"
+        match_id = "common_id"
+        field_update = "target_field"
+
+        from st_app import handle_merge_update_action
+        handle_merge_update_action(master_path, update_path, match_id, field_update)
+
+        expected_query = f"""
+        MERGE `{master_path}` T
+        USING `{update_path}` S
+        ON T.{match_id} = S.{match_id}
+        WHEN MATCHED THEN
+          UPDATE SET T.{field_update} = S.{field_update}
+        """
+        mock_st.info.assert_any_call(f"Initiating MERGE operation to update '{field_update}' in '{master_path}' using '{update_path}' on matching '{match_id}'.")
+        mock_execute_merge_query.assert_called_once_with(expected_query.strip(), 'proj')
+        mock_load_all_data.assert_called_once_with(project_id='proj', dataset_id='dataset', table_id='master_table')
+        mock_display_data.assert_called_once_with(sample_data)
+        mock_st.success.assert_any_call("MERGE operation completed successfully.")
+
+    @patch('st_app.display_data')
+    @patch('st_app.bq_utils.load_all_data_from_bq')
+    @patch('st_app.bq_utils.execute_merge_query')
+    @patch('st_app.st')
+    def test_handle_merge_update_action_merge_fails(self, mock_st, mock_execute_merge_query, mock_load_all_data, mock_display_data):
+        mock_execute_merge_query.return_value = False
+
+        master_path = "proj.dataset.master_table"
+        update_path = "proj.dataset.update_table"
+        match_id = "common_id"
+        field_update = "target_field"
+
+        from st_app import handle_merge_update_action
+        handle_merge_update_action(master_path, update_path, match_id, field_update)
+
+        mock_st.error.assert_any_call("MERGE operation failed. Check logs for details.")
+        mock_load_all_data.assert_not_called()
+        mock_display_data.assert_not_called()
+
+    @patch('st_app.bq_utils.execute_merge_query')
+    @patch('st_app.st')
+    def test_handle_merge_update_action_invalid_paths(self, mock_st, mock_execute_merge_query):
+        from st_app import handle_merge_update_action
+
+        invalid_paths_to_test = [
+            ("proj.dataset", "proj.dataset.update", "id", "field"), # Master path invalid
+            ("proj.dataset.master", "proj.update", "id", "field"),   # Update path invalid
+            ("", "proj.dataset.update", "id", "field"),              # Master path empty
+            ("proj.dataset.master", "", "id", "field"),              # Update path empty
+            ("p.d.t.e", "p.d.u", "id", "field")                      # Master path too many parts
+        ]
+
+        for paths in invalid_paths_to_test:
+            mock_st.error.reset_mock() # Reset mock for each iteration
+            mock_execute_merge_query.reset_mock()
+
+            handle_merge_update_action(*paths)
+
+            mock_st.error.assert_called_once() # Check that st.error was called
+            self.assertIn("Invalid BigQuery", mock_st.error.call_args[0][0]) # Check part of the error message
+            mock_execute_merge_query.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit refactors the 'Update Fields' section in the Streamlit application.

The following changes were made:

- The UI now accepts four text inputs:
    - Master Table Path
    - Update Table Path
    - Matching ID
    - Field to Update
- The application constructs and executes a BigQuery MERGE statement based on these inputs to update the master table.
- After the MERGE operation, the updated master table data is fetched and displayed.
- The previous CSV upload functionality for updates has been removed.

New functions:
- `st_app.handle_merge_update_action`: Orchestrates the MERGE update logic in the Streamlit app.
- `bq_utils.execute_merge_query`: Executes a given MERGE SQL query in BigQuery.

Unit tests have been added for the new functions to cover successful execution, error handling, and invalid input scenarios.