### PR TITLE
Fix: Align merge query mock assertion with actual call

### DIFF
--- a/test_st_app.py
+++ b/test_st_app.py
@@ -287,7 +287,7 @@ class TestHandleMergeUpdateAction(unittest.TestCase):
           UPDATE SET T.{field_update} = S.{field_update}
         """
         mock_st.info.assert_any_call(f"Initiating MERGE operation to update '{field_update}' in '{master_path}' using '{update_path}' on matching '{match_id}'.")
-        mock_execute_merge_query.assert_called_once_with(expected_query.strip(), 'proj')
+        mock_execute_merge_query.assert_called_once_with(expected_query, project_id='proj')
         mock_load_all_data.assert_called_once_with(project_id='proj', dataset_id='dataset', table_id='master_table')
         mock_display_data.assert_called_once_with(sample_data)
         mock_st.success.assert_any_call("MERGE operation completed successfully.")


### PR DESCRIPTION
The test `TestHandleMergeUpdateAction.test_handle_merge_update_action_success` was failing because the mock assertion for `execute_merge_query` did not precisely match the actual call in `st_app.py`.

The discrepancies were:
1. Whitespace: The actual query string passed to `execute_merge_query` retained leading/trailing newlines from the f-string definition, while the test expected the string with these newlines stripped.
2. Argument Passing: The `project_id` was passed as a keyword argument in the actual call (`project_id='proj'`), but the test expected it as a positional argument (`'proj'`).

This commit updates the assertion in `test_st_app.py` to reflect the actual call by:
- Removing `.strip()` from the expected query string.
- Using `project_id='proj'` in the assertion.

All tests now pass after this change.