### PR TITLE
Fix: Align tests with removal of master table update

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -739,55 +739,9 @@ def main_ui():
                             st.info("Returning the table with Gemini insights for user front end")
                             st.dataframe(insights_df)
 
-                            # Prepare insights_df for update
-                            # The faulty try-except block referencing main_table_path has been removed.
-                            if 'fhrsid' not in insights_df.columns:
-                                st.error("FHRSID column is missing in Gemini insights. Cannot update main table.")
-                                st.stop()
-                            elif 'gemini_insights' not in insights_df.columns: # Changed to elif
-                                st.error("gemini_insights column is missing. Cannot update main table.")
-                                st.stop()
-                            else:
-                                # Use bq_source_table_input as requested
-                                try:
-                                    # bq_source_table_input is defined above in the same function scope
-                                    main_project_id, main_dataset_id, main_table_id = bq_source_table_input.split('.')
-                                    if not all([main_project_id, main_dataset_id, main_table_id]):
-                                        raise ValueError("Each part of the BigQuery table path must be non-empty.")
-                                except ValueError as e:
-                                    st.error(f"Invalid BigQuery table path for the main table: '{bq_source_table_input}'. Error: {e}")
-                                    st.stop()
+                            # The BigQuery update block has been removed as per the requirement.
+                            # The insights_df is displayed above, and no further BQ update happens here.
 
-                                st.info(f"Attempting to update table {main_project_id}.{main_dataset_id}.{main_table_id} with Gemini insights...")
-                                success_count = 0
-                                error_count = 0
-
-                                for index, row in insights_df.iterrows():
-                                    fhrsid = str(row['fhrsid']) # Ensure fhrsid is a string
-                                    insight_text = row['gemini_insights']
-
-                                    update_payload = {'gemini_insights': insight_text}
-
-                                    # Call bq_utils.update_rows_in_bigquery
-                                    # Assuming bq_utils is imported at the top of the file
-                                    updated_successfully = update_rows_in_bigquery(
-                                        project_id=main_project_id,
-                                        dataset_id=main_dataset_id,
-                                        table_id=main_table_id,
-                                        fhrsid=fhrsid,
-                                        update_data=update_payload
-                                    )
-
-                                    if updated_successfully:
-                                        success_count += 1
-                                    else:
-                                        error_count += 1
-                                        st.warning(f"Failed to update insights for FHRSID {fhrsid}. Check logs.")
-
-                                if error_count > 0:
-                                    st.error(f"Update summary: Successfully updated {success_count} rows. Failed to update {error_count} rows.")
-                                else:
-                                    st.success(f"Successfully updated {success_count} rows with Gemini insights.")
                         else:
                             st.warning("No insights were generated or returned, so the main table was not updated.")
 

--- a/test_st_app.py
+++ b/test_st_app.py
@@ -109,8 +109,8 @@ class TestRecentRestaurantAnalysisGeminiUpdate(unittest.TestCase):
         main_ui()
 
         self.mock_call_gemini.assert_called_once_with(project_id="test_project", dataset_id="test_dataset", gemini_prompt=ANY)
-        self.assertEqual(self.mock_update_bq.call_count, 2)
-        mock_st_global.success.assert_any_call("Successfully updated 2 rows with Gemini insights.")
+        self.mock_update_bq.assert_not_called()
+        # The success message related to BQ update is removed as the update logic is gone.
 
     def test_missing_fhrsid_column_in_insights_df(self, mock_st_global):
         self._setup_initial_session_state(mock_st_global)
@@ -134,8 +134,7 @@ class TestRecentRestaurantAnalysisGeminiUpdate(unittest.TestCase):
         main_ui()
 
         self.mock_call_gemini.assert_called_once() # Gemini should be called
-        mock_st_global.error.assert_any_call("FHRSID column is missing in Gemini insights. Cannot update main table.")
-        mock_st_global.stop.assert_called_once()
+        # The error message and stop call related to missing 'fhrsid' for the update block are removed.
         self.mock_update_bq.assert_not_called()
 
 
@@ -214,8 +213,7 @@ class TestRecentRestaurantAnalysisGeminiUpdate(unittest.TestCase):
         main_ui() # Gemini run
 
         self.mock_call_gemini.assert_called_once()
-        mock_st_global.error.assert_any_call("gemini_insights column is missing. Cannot update main table.")
-        mock_st_global.stop.assert_called_once()
+        # The error message and stop call related to missing 'gemini_insights' for the update block are removed.
         self.mock_update_bq.assert_not_called()
 
 
@@ -233,10 +231,9 @@ class TestRecentRestaurantAnalysisGeminiUpdate(unittest.TestCase):
         self.mock_call_gemini.assert_called_once()
         # Corrected expected error message string representation
         actual_exception_message = "not enough values to unpack (expected 3, got 2)"
-        expected_error_message = f"Invalid BigQuery table path for the main table: '{invalid_path}'. Error: {actual_exception_message}"
-
-        mock_st_global.error.assert_any_call(expected_error_message)
-        mock_st_global.stop.assert_called_once()
+        # The specific error message check for the main table update path is removed.
+        # The st.stop() call associated with that error is also removed.
+        # The test now primarily ensures that Gemini was called and BQ update was not.
         self.mock_update_bq.assert_not_called()
 
 
@@ -255,10 +252,8 @@ class TestRecentRestaurantAnalysisGeminiUpdate(unittest.TestCase):
         main_ui() # Gemini run
 
         self.mock_call_gemini.assert_called_once()
-        self.assertEqual(self.mock_update_bq.call_count, 2)
-        mock_st_global.warning.assert_any_call("Failed to update insights for FHRSID 789. Check logs.")
-        mock_st_global.warning.assert_any_call("Failed to update insights for FHRSID 890. Check logs.")
-        mock_st_global.error.assert_any_call("Update summary: Successfully updated 0 rows. Failed to update 2 rows.")
+        self.mock_update_bq.assert_not_called()
+        # Warning and error messages related to BQ update failures are removed.
 
 
 class TestHandleMergeUpdateAction(unittest.TestCase):


### PR DESCRIPTION
Updates tests in test_st_app.py to reflect the changes made in the 'Recent Restaurant Analysis' feature. Previously, this feature updated a master BigQuery table with Gemini insights. This update functionality was removed.

The test changes include:
- Removing assertions that checked for error messages or success/warning messages related to the master table update.
- Replacing assertions that checked the call count of the BigQuery update mock with assertions verifying it is no longer called.

The tests now correctly validate the current behavior where the process stops after generating and displaying insights from the 'genairesults_temp' table.