### PR TITLE
Fix: Remove RatingDate from BQ append schema

### DIFF
--- a/st_app.py
+++ b/st_app.py
@@ -215,7 +215,7 @@ def _append_new_data_to_bigquery(new_restaurants: List[Dict[str, Any]], project_
         bigquery.SchemaField(sanitize_column_name('PostCode'), 'STRING'),
         bigquery.SchemaField(sanitize_column_name('RatingValue'), 'STRING'), # Can be "Pass", "Exempt", or number
         bigquery.SchemaField(sanitize_column_name('RatingKey'), 'STRING'),
-        bigquery.SchemaField(sanitize_column_name('RatingDate'), 'STRING'), # Or DATE if time component is not important
+        # RatingDate removed as it's not in ORIGINAL_COLUMNS_TO_KEEP and causes a warning
         bigquery.SchemaField(sanitize_column_name('LocalAuthorityCode'), 'STRING'),
         bigquery.SchemaField(sanitize_column_name('LocalAuthorityName'), 'STRING'),
         bigquery.SchemaField(sanitize_column_name('LocalAuthorityWebSite'), 'STRING'),


### PR DESCRIPTION
Removes 'RatingDate' from the 'bq_schema_for_append' in 'st_app.py'. This aligns the schema with the actual columns processed (defined in ORIGINAL_COLUMNS_TO_KEEP), resolving the warning:
'Column 'ratingdate' (expected for RatingDate) not found. It will be skipped for BQ append.'